### PR TITLE
Update intel url in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     "cookies",
     "storage",
     "webNavigation",
-    "https://*.ingress.com/intel",
+    "https://intel.ingress.com/*",
     "https://iitc.modos189.ru/*",
     "http://*/*.json",
     "http://*/*.meta.js",


### PR DESCRIPTION
If the user loads https://intel.ingress.com/ with the current manifest, the button doesn't do anything