### PR TITLE
More storage space

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,8 @@
     "storage",
     "<all_urls>",
     "webRequest",
-    "webRequestBlocking"
+    "webRequestBlocking",
+    "unlimitedStorage"
   ],
   "default_locale": "en",
   "background": {


### PR DESCRIPTION
for big custom plugins

Stuff >1mb (or 2?) will create an exception and won't be stored