### PR TITLE
Implemented a non-site-specific storage for GM functions 

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -55,9 +55,6 @@ browser.runtime.onMessage.addListener(async request => {
     case "toggleIITC":
       await onToggleIITC(request.value);
       break;
-    case "xmlHttpRequestHandler":
-      await xmlHttpRequestHandler(request.value);
-      break;
   }
 });
 
@@ -106,44 +103,3 @@ browser.runtime.onMessage.addListener(async function(request) {
       break;
   }
 });
-
-async function xmlHttpRequestHandler(data) {
-  async function xmlResponse(tab_id, callback, response) {
-    const detail_stringify = JSON.stringify({
-      uuid: data.uuid,
-      response: JSON.stringify(response)
-    });
-
-    const injectedCode = `
-    document.dispatchEvent(new CustomEvent('onXmlHttpRequestHandler', {
-      detail: "${btoa(String(detail_stringify))}"
-    }));
-  `;
-
-    try {
-      await browser.tabs.executeScript(data.tab_id, {
-        code: injectedCode
-      });
-    } catch (error) {
-      console.error(`An error occurred while execute script: ${error.message}`);
-    }
-  }
-
-  const req = new XMLHttpRequest();
-  req.onload = function() {
-    const response = {
-      readyState: this.readyState,
-      responseHeaders: this.responseHeaders,
-      responseText: this.responseText,
-      status: this.status,
-      statusText: this.statusText
-    };
-    xmlResponse(data.tab_id, data.onload, response);
-  };
-  req.open(data.method, data.url, true, data.user, data.password);
-  for (let [header_name, header_value] of Object.entries(data.headers)) {
-    req.setRequestHeader(header_name, header_value);
-  }
-
-  req.send(data.data);
-}

--- a/src/content-scripts/bridge.js
+++ b/src/content-scripts/bridge.js
@@ -24,39 +24,12 @@ export async function bridgeAction(e) {
 }
 
 const xmlResponseBridge = async data => {
-  async function xmlResponse(tab_id, callback, response) {
-    const detail_stringify = JSON.stringify({
-      task_uuid: data.task_uuid,
-      task_type: data.task_type,
-      response: JSON.stringify(response)
-    });
-
-    const injectedCode = `
-      document.dispatchEvent(new CustomEvent('bridgeResponse', {
-        detail: "${btoa(String(detail_stringify))}"
-      }));
-    `;
-
-    inject(injectedCode);
-  }
-
-  const req = new XMLHttpRequest();
-  req.onload = function() {
-    const response = {
-      readyState: this.readyState,
-      responseHeaders: this.responseHeaders,
-      responseText: this.responseText,
-      status: this.status,
-      statusText: this.statusText
-    };
-    xmlResponse(data.tab_id, data.onload, response);
-  };
-  req.open(data.method, data.url, true, data.user, data.password);
-  for (let [header_name, header_value] of Object.entries(data.headers)) {
-    req.setRequestHeader(header_name, header_value);
-  }
-
-  req.send(data.data);
+  browser.runtime
+    .sendMessage({
+      type: "xmlHttpRequestHandler",
+      value: data
+    })
+    .then();
 };
 
 // Sends the entire plugin scoped storage to the page context

--- a/src/content-scripts/bridge.js
+++ b/src/content-scripts/bridge.js
@@ -3,8 +3,18 @@
 import { inject } from "@/content-scripts/utils";
 
 export async function bridgeAction(e) {
-  const data = e.detail;
+  const task = e.detail;
 
+  switch (task.task_type) {
+    case "xmlHttpRequest":
+      await xmlResponseBridge(task);
+      break;
+    default:
+      return;
+  }
+}
+
+const xmlResponseBridge = async data => {
   async function xmlResponse(tab_id, callback, response) {
     const detail_stringify = JSON.stringify({
       task_uuid: data.task_uuid,
@@ -38,4 +48,4 @@ export async function bridgeAction(e) {
   }
 
   req.send(data.data);
-}
+};

--- a/src/content-scripts/bridge.js
+++ b/src/content-scripts/bridge.js
@@ -32,19 +32,18 @@ const xmlResponseBridge = async data => {
     .then();
 };
 
-// Sends the entire plugin scoped storage to the page context
+// Sends the entire plugins scoped storage to the page context
 const getStorageBridge = async req => {
   const all_storage = await browser.storage.local.get(null);
-  const plugin_storage = {};
+  const plugins_storage = {};
   for (const key in all_storage) {
-    if (key.startsWith(req.data_key)) {
-      plugin_storage[key] = all_storage[key];
+    if (key.startsWith("VMin")) {
+      plugins_storage[key] = all_storage[key];
     }
   }
   const detail_stringify = JSON.stringify({
-    task_uuid: req.task_uuid,
     task_type: req.task_type,
-    response: JSON.stringify(plugin_storage)
+    response: JSON.stringify(plugins_storage)
   });
 
   const injectedCode = `

--- a/src/content-scripts/bridge.js
+++ b/src/content-scripts/bridge.js
@@ -1,0 +1,41 @@
+//@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+
+import { inject } from "@/content-scripts/utils";
+
+export async function bridgeAction(e) {
+  const data = e.detail;
+
+  async function xmlResponse(tab_id, callback, response) {
+    const detail_stringify = JSON.stringify({
+      task_uuid: data.task_uuid,
+      task_type: data.task_type,
+      response: JSON.stringify(response)
+    });
+
+    const injectedCode = `
+  document.dispatchEvent(new CustomEvent('bridgeResponse', {
+    detail: "${btoa(String(detail_stringify))}"
+  }));
+`;
+
+    inject(injectedCode);
+  }
+
+  const req = new XMLHttpRequest();
+  req.onload = function() {
+    const response = {
+      readyState: this.readyState,
+      responseHeaders: this.responseHeaders,
+      responseText: this.responseText,
+      status: this.status,
+      statusText: this.statusText
+    };
+    xmlResponse(data.tab_id, data.onload, response);
+  };
+  req.open(data.method, data.url, true, data.user, data.password);
+  for (let [header_name, header_value] of Object.entries(data.headers)) {
+    req.setRequestHeader(header_name, header_value);
+  }
+
+  req.send(data.data);
+}

--- a/src/content-scripts/loader.js
+++ b/src/content-scripts/loader.js
@@ -1,6 +1,6 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 import { GM } from "./gm-api";
-import { inject, xmlHttpRequestBridge, IITCButtonInitJS } from "./utils";
+import { inject, bridgeAction, IITCButtonInitJS } from "./utils";
 
 function preparePage() {
   document.addEventListener("DOMContentLoaded", function() {
@@ -15,7 +15,7 @@ function preparePage() {
       "js/GM_api.js"
     )}`
   );
-  document.addEventListener("xmlHttpRequestBridge", xmlHttpRequestBridge);
+  document.addEventListener("bridgeRequest", bridgeAction);
   document.addEventListener("IITCButtonInitJS", IITCButtonInitJS);
 }
 

--- a/src/content-scripts/loader.js
+++ b/src/content-scripts/loader.js
@@ -1,6 +1,7 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 import { GM } from "./gm-api";
-import { inject, bridgeAction, IITCButtonInitJS } from "./utils";
+import { inject, IITCButtonInitJS } from "./utils";
+import { bridgeAction } from "@/content-scripts/bridge";
 
 function preparePage() {
   document.addEventListener("DOMContentLoaded", function() {

--- a/src/content-scripts/utils.js
+++ b/src/content-scripts/utils.js
@@ -18,44 +18,6 @@ export function inject(code) {
   script.parentElement.removeChild(script);
 }
 
-export async function bridgeAction(e) {
-  const data = e.detail;
-
-  async function xmlResponse(tab_id, callback, response) {
-    const detail_stringify = JSON.stringify({
-      task_uuid: data.task_uuid,
-      task_type: data.task_type,
-      response: JSON.stringify(response)
-    });
-
-    const injectedCode = `
-  document.dispatchEvent(new CustomEvent('bridgeResponse', {
-    detail: "${btoa(String(detail_stringify))}"
-  }));
-`;
-
-    inject(injectedCode);
-  }
-
-  const req = new XMLHttpRequest();
-  req.onload = function() {
-    const response = {
-      readyState: this.readyState,
-      responseHeaders: this.responseHeaders,
-      responseText: this.responseText,
-      status: this.status,
-      statusText: this.statusText
-    };
-    xmlResponse(data.tab_id, data.onload, response);
-  };
-  req.open(data.method, data.url, true, data.user, data.password);
-  for (let [header_name, header_value] of Object.entries(data.headers)) {
-    req.setRequestHeader(header_name, header_value);
-  }
-
-  req.send(data.data);
-}
-
 export async function IITCButtonInitJS(e) {
   const tab_id = e.detail.tab_id;
   const code = e.detail.code;

--- a/src/content-scripts/utils.js
+++ b/src/content-scripts/utils.js
@@ -1,11 +1,6 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
-import {
-  getUID,
-  getUniqId,
-  parseMeta,
-  check_meta_match_pattern
-} from "lib-iitc-manager";
+import { getUID, parseMeta, check_meta_match_pattern } from "lib-iitc-manager";
 
 const LOADED_PLUGINS = [];
 
@@ -18,6 +13,10 @@ export function inject(code) {
   script.parentElement.removeChild(script);
 }
 
+function getPluginHash(uid) {
+  return "VMin" + btoa(uid);
+}
+
 export async function IITCButtonInitJS(e) {
   const tab_id = e.detail.tab_id;
   const code = e.detail.code;
@@ -26,12 +25,7 @@ export async function IITCButtonInitJS(e) {
   const uid = getUID(meta);
   meta["uid"] = uid;
 
-  let dataKey = sessionStorage.getItem(uid);
-  if (!dataKey) {
-    dataKey = getUniqId("VMin");
-    sessionStorage.setItem(uid, dataKey);
-  }
-
+  let data_key = getPluginHash(uid);
   if (LOADED_PLUGINS.includes(uid)) {
     console.debug(`Plugin ${uid} is already loaded. Skip`);
   } else {
@@ -56,7 +50,7 @@ export async function IITCButtonInitJS(e) {
       code,
       // adding a new line in case the code ends with a line comment
       code.endsWith("\n") ? "" : "\n",
-      `})(GM("${dataKey}", ${tab_id}, ${JSON.stringify(meta)}))`,
+      `})(GM("${data_key}", ${tab_id}, ${JSON.stringify(meta)}))`,
 
       // Firefox lists .user.js among our own content scripts so a space at start will group them
       `\n//# sourceURL=${browser.runtime.getURL(


### PR DESCRIPTION
Past implementations of storage for GM API (like GM_getValue, GM_setValue) used `sessionStorage` in page context. This prevented storing plugin data between sessions and different sites.

The new implementation uses persistent storage at `browser.storage.local`. When the plugins start up, data is copied using a bridge from `browser.storage.local` to the `storage` variable. Changes in `storage` through the bridge are duplicated in `browser.storage.local`