### PR TITLE
Only reload Ingress Intel tabs on toggle

### DIFF
--- a/src/background/intel.js
+++ b/src/background/intel.js
@@ -29,7 +29,9 @@ export async function onToggleIITC(value) {
   const tabs = await getTabsToInject();
 
   for (let tab of Object.values(tabs)) {
-    await browser.tabs.reload(tab.id);
+    if (isIngressIntelUrl(tab.url)) {
+      await browser.tabs.reload(tab.id);
+    }
   }
 }
 


### PR DESCRIPTION
The current behaviour ends up reloading every open tab because neither `onToggleIITC` nor `getTabsToInject` actually check the URL of each tab.  This change updates the former to minimise the scope (other callers of `getTabsToInject` seem to be doing their own URL checks anyway).