### PR TITLE
Manifest V3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - build_script: build_mv2
+          - build_script: build_mv3_firefox
+          - build_script: build_mv3_chrome
+          - build_script: build_mv3_safari
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         run: npm ci
@@ -29,7 +36,7 @@ jobs:
         run: npm run lint
 
       - name: Build
-        run: npm run build
+        run: npm run ${{ matrix.build_script }}
 
       - name: Get version from package.json
         if: startsWith(github.ref, 'refs/tags/v')
@@ -41,34 +48,72 @@ jobs:
       - name: Save metadata
         run: |
           mkdir -p ./build/.metadata
+          ORIGINAL_FILE_NAME=$(ls artifacts/*.zip)
+          FILE_NAME="${ORIGINAL_FILE_NAME##*/}"
+          FILE_NAME="${FILE_NAME%.zip}"
+
           if [ "$GITHUB_EVENT_NAME" = "push" ]; then
             if [[ "$GITHUB_REF" =~ ^refs/tags/ ]]; then
-              mv artifacts/*.zip ./build/iitc-button-${{steps.get-version-key-from-json.outputs.version}}.zip
+              # Release build
               echo "release" > ./build/.metadata/build_type
             else
               # Beta build from master branch
-              mv artifacts/*.zip ./build/iitc-button-${{github.sha}}.zip
+              FILE_NAME="${FILE_NAME}-$(echo ${{ github.sha }} | cut -c 1-6)"
               echo "beta" > ./build/.metadata/build_type
             fi
             echo ${{ github.sha }} > ./build/.metadata/commit
           elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            mv artifacts/*.zip ./build/iitc-button-${{github.event.pull_request.head.sha}}.zip
+            # Build artifacts for PR
+            FILE_NAME="${FILE_NAME}-$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-6)"
             echo "PR" > ./build/.metadata/build_type
             echo ${{ github.event.pull_request.head.sha }} > ./build/.metadata/commit
           fi
-          echo $( ls ./build/ | grep '.zip' ) > ./build/.metadata/zip_filename
+
+          mv $ORIGINAL_FILE_NAME "./build/$FILE_NAME".zip
           echo "GITHUB_SHA_SHORT=$(cat ./build/.metadata/commit | cut -c 1-6)" >> $GITHUB_ENV
+          echo "FILE_NAME=$FILE_NAME" >> $GITHUB_ENV
 
       - uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          FILE_PATH: ./build/${{ env.FILE_NAME }}
         with:
           allowUpdates: true
           artifactErrorsFailBuild: true
-          artifacts: "./build/iitc-button-${{ steps.get-version-key-from-json.outputs.version }}.zip"
+          artifacts: ${{ env.FILE_PATH }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
-          name: iitc-button-${{ env.GITHUB_SHA_SHORT }}-artifact
+          name: ${{ env.FILE_NAME }}
           path: |
             ./build/
+
+  collect:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: collected_artifacts
+
+      - name: Move artifacts to final directory
+        run: |
+          mkdir -p final_artifacts
+          echo "Moving contents from artifact directories to final_artifacts directory:"
+          for dir in collected_artifacts/*; do
+            if [ -d "$dir" ]; then
+              cp -rf "$dir"/* "$dir"/.metadata final_artifacts/
+            fi
+          done
+          echo "Contents of final_artifacts directory:"
+          ls -la final_artifacts/
+
+      - name: Get metadata
+        run: echo "GITHUB_SHA_SHORT=$(cat ./final_artifacts/.metadata/commit | cut -c 1-6)" >> $GITHUB_ENV
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: iitc-button-${{ env.GITHUB_SHA_SHORT }}-artifacts
+          path: final_artifacts/*

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -1,23 +1,49 @@
 name: Add artifact links to pull request
+
 on:
   workflow_run:
-    workflows: ['Build IITC Button']
+    workflows: ["Build IITC Button"]
     types: [completed]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  artifacts-url-comments:
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+  comment-links:
     runs-on: ubuntu-latest
     steps:
-      - name: add artifact links to pull request and related issues step
-        uses: tonyhallett/artifacts-url-comments@v1.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get artifact list from API
+        id: get-artifacts
+        uses: actions/github-script@v7
         with:
-          prefix: Here are the build results
-          suffix: Artifacts will only be retained for 90 days.
-          format: url
-          addTo: pull
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runId = ${{ github.event.workflow_run.id }};
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId
+            });
+            artifacts.data.artifacts.forEach((artifact, index) => {
+              const nameVar = `artifact${index + 1}`;
+              const urlVar = `url${index + 1}`;
+              let displayName = artifact.name.endsWith('-artifacts') ? `**${artifact.name}**` : artifact.name;
+              core.exportVariable(nameVar, displayName);
+              core.exportVariable(urlVar, `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${artifact.id}`);
+            });
+
+      - name: Comment with artifact links for PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr_artifacts
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          message: |
+            Build completed successfully. Below are the download links for the build artifacts:
+            
+            | Artifact Name | Download Link |
+            | ------------- | ------------- |
+            | ${{ env.artifact1 }} | [Download](${{ env.url1 }}) |
+            | ${{ env.artifact2 }} | [Download](${{ env.url2 }}) |
+            | ${{ env.artifact3 }} | [Download](${{ env.url3 }}) |
+            | ${{ env.artifact4 }} | [Download](${{ env.url4 }}) |
+            | ${{ env.artifact5 }} | [Download](${{ env.url5 }}) |
+            
+            Artifacts will only be retained for 90 days.

--- a/README.md
+++ b/README.md
@@ -36,14 +36,18 @@ Theoretically, you violates ToS, but as you totally relies on intel.ingress.com 
 npm install
 ```
 
-### Compiles and hot-reloads for development
+### Compiles and minifies for production with Manifest V2
 ```
-npm run serve
+npm run build_mv2
 ```
 
-### Compiles and minifies for production
+### Compiles and minifies for production with Manifest V3
 ```
-npm run build
+npm run build_mv3_firefox
+# or
+npm run build_mv3_chrome
+# or
+npm run build_mv3_safari
 ```
 
 ### Lints and fixes files
@@ -59,7 +63,7 @@ See [Configuration Reference](https://cli.vuejs.org/config/).
 ## Build for Safari (MacOS and iOS)
 
 1. Follow the [general build instructions](#project-setup).
-To build for iOS, set the _BROWSER="safari-ios"_ environment variable (example: `BROWSER="safari-ios" npm run build`)
+To build for iOS, set the _BROWSER="safari-ios"_ environment variable (example: `BROWSER="safari-ios" npm run build`). Tested only on Manifest V2.
 
 2. Open the Xcode project in the `safari` folder
 
@@ -76,5 +80,4 @@ To develop without a certificate, tell Safari to load unsigned extensions using 
    * Choose Safari > Preferences.
    * Select the Extensions tab. This tab shows the localized description, display name, and version number for the selected Safari App Extension. It also provides more information about the permissions claimed by the extension.
    * Find your new extension in the list on the left, and enable it by selecting the checkbox.
-
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "core-js": "^3.8.3",
         "highlight.js": "^10.7.3",
         "jszip": "^3.10.1",
-        "lib-iitc-manager": "^1.8.4",
+        "lib-iitc-manager": "^1.9.0",
         "scored-fuzzysearch": "^1.0.5",
         "vue": "^2.6.14"
       },
@@ -9460,9 +9460,9 @@
       }
     },
     "node_modules/lib-iitc-manager": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-1.8.4.tgz",
-      "integrity": "sha512-1Mk58EgTbUDR7DOZAqx8oEWaFvu8kuhyZPyyuAIYYDf91jAdr61Ht3/rtQYOSXPIQGTj+sbgN5musk40puverQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-1.9.0.tgz",
+      "integrity": "sha512-8baF0kySzDQIqNv8+eSLNhjHN+jQIG8TLKvENDNVSaE4dWmdyF0IjWaYqxxE06+uwQktQG3XeY49QLYelmBscw==",
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "xhr2": "^0.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "core-js": "^3.8.3",
         "highlight.js": "^10.7.3",
         "jszip": "^3.10.1",
-        "lib-iitc-manager": "^1.8.3",
+        "lib-iitc-manager": "^1.8.4",
         "scored-fuzzysearch": "^1.0.5",
         "vue": "^2.6.14"
       },
@@ -2933,6 +2933,48 @@
         }
       }
     },
+    "node_modules/@vue/cli-service/node_modules/copy-webpack-plugin": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+      "integrity": "sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "glob-parent": "^6.0.1",
+        "globby": "^11.0.3",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^3.1.1",
+        "serialize-javascript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/@vue/cli-service/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/@vue/cli-shared-utils": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-5.0.8.tgz",
@@ -5305,48 +5347,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
-      "integrity": "sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==",
-      "dev": true,
-      "dependencies": {
-        "fast-glob": "^3.2.7",
-        "glob-parent": "^6.0.1",
-        "globby": "^11.0.3",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/core-js": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "license": "GPLv3",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service build --mode development --watch",
-    "build": "vue-cli-service build",
+    "build_mv2": "export MANIFEST_VERSION=2 && vue-cli-service build",
+    "build_mv3_firefox": "export MANIFEST_VERSION=3 && export BROWSER=firefox && vue-cli-service build",
+    "build_mv3_chrome": "export MANIFEST_VERSION=3 && export BROWSER=chrome && vue-cli-service build",
+    "build_mv3_safari": "export MANIFEST_VERSION=3 && export BROWSER=safari && vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "core-js": "^3.8.3",
     "highlight.js": "^10.7.3",
     "jszip": "^3.10.1",
-    "lib-iitc-manager": "^1.8.4",
+    "lib-iitc-manager": "^1.9.0",
     "scored-fuzzysearch": "^1.0.5",
     "vue": "^2.6.14"
   },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -262,5 +262,11 @@
     },
     "saveToJson": {
         "message": "Save to json"
+    },
+    "alertChromeRequiresDevModeTitle": {
+        "message": "Our extension requires Developer&nbsp;Mode to be enabled to manage UserScripts, due to Manifest&nbsp;V3 limitations in Chrome. It's easy to enable!"
+    },
+    "alertChromeRequiresDevModeButton": {
+        "message": "Please follow this guide."
     }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -267,6 +267,15 @@
         "message": "Our extension requires Developer&nbsp;Mode to be enabled to manage UserScripts, due to Manifest&nbsp;V3 limitations in Chrome. It's easy to enable!"
     },
     "alertChromeRequiresDevModeButton": {
-        "message": "Please follow this guide."
+        "message": "Please follow this guide"
+    },
+    "alertHostPermissionsRequiredTitle": {
+        "message": "Provide access to URLs for userscripts to work. You will be able to change your choice in your browser settings."
+    },
+    "alertHostPermissionsRequiredButtonIntel": {
+        "message": "Ingress Intel only"
+    },
+    "alertHostPermissionsRequiredButtonAllUrls": {
+        "message": "All URLs to ensure full support"
     }
 }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,7 +1,11 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 import { Manager } from "lib-iitc-manager";
 import browser from "webextension-polyfill";
-import { IS_SCRIPTING_API, IS_USERSCRIPTS_API } from "@/userscripts/env";
+import {
+  IS_LEGACY_API,
+  IS_SCRIPTING_API,
+  IS_USERSCRIPTS_API,
+} from "@/userscripts/env";
 import { _ } from "@/i18n";
 import {
   onUpdatedListener,
@@ -58,7 +62,7 @@ const manager = new Manager({
 
 manager.run().then();
 
-if (IS_SCRIPTING_API) {
+if (IS_LEGACY_API || IS_SCRIPTING_API) {
   const { onUpdated, onRemoved } = browser.tabs;
   onUpdated.addListener((tabId, status, tab) =>
     onUpdatedListener(tabId, status, tab, manager)

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -3,11 +3,7 @@ import { Manager } from "lib-iitc-manager";
 import browser from "webextension-polyfill";
 import { IS_SCRIPTING_API, IS_USERSCRIPTS_API } from "@/userscripts/env";
 import { _ } from "@/i18n";
-import {
-  inject_gm_api,
-  inject_plugin,
-  is_userscripts_api_available,
-} from "@/userscripts/wrapper";
+import { inject_gm_api, inject_plugin } from "@/userscripts/wrapper";
 import {
   onUpdatedListener,
   onRemovedListener,
@@ -16,7 +12,10 @@ import {
 } from "./intel";
 import "./requests";
 import { strToBase64 } from "@/strToBase64";
-import { isIITCEnabled } from "@/userscripts/utils";
+import {
+  is_userscripts_api_available,
+  is_iitc_enabled,
+} from "@/userscripts/utils";
 
 const manager = new Manager({
   storage: browser.storage.local,
@@ -44,7 +43,7 @@ const manager = new Manager({
       // If popup is closed, message goes nowhere and an error occurs. Ignore.
     }
     if (IS_USERSCRIPTS_API) {
-      isIITCEnabled().then((status) => {
+      is_iitc_enabled().then((status) => {
         if (status) {
           init_userscripts_api();
           manager.inject().then();
@@ -146,6 +145,18 @@ browser.runtime.onMessage.addListener(async function (request) {
               request.params,
               request.backup_data
             ),
+          })
+          .then();
+      } catch {
+        // If tab is closed, message goes nowhere and an error occurs. Ignore.
+      }
+      break;
+    case "checkUserScriptsApiAvailable":
+      try {
+        browser.runtime
+          .sendMessage({
+            type: "resolveCheckUserScriptsApiAvailable",
+            data: is_userscripts_api_available(),
           })
           .then();
       } catch {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -24,28 +24,22 @@ import {
 const manager = new Manager({
   storage: browser.storage.local,
   message: (message, args) => {
-    try {
-      browser.runtime
-        .sendMessage({
-          type: "showMessage",
-          message: _(message, args),
-        })
-        .then();
-    } catch {
-      // If popup is closed, message goes nowhere and an error occurs. Ignore.
-    }
+    browser.runtime
+      .sendMessage({
+        type: "showMessage",
+        message: _(message, args),
+      })
+      .then()
+      .catch(() => {}); // If popup is closed, message goes nowhere and an error occurs. Ignore.
   },
   progressbar: (is_show) => {
-    try {
-      browser.runtime
-        .sendMessage({
-          type: "showProgressbar",
-          value: is_show,
-        })
-        .then();
-    } catch {
-      // If popup is closed, message goes nowhere and an error occurs. Ignore.
-    }
+    browser.runtime
+      .sendMessage({
+        type: "showProgressbar",
+        value: is_show,
+      })
+      .then()
+      .catch(() => {}); // If popup is closed, message goes nowhere and an error occurs. Ignore.
   },
   inject_plugin: async (plugin) => {
     if (IS_USERSCRIPTS_API) return;
@@ -103,67 +97,52 @@ browser.runtime.onMessage.addListener(async (request) => {
     case "addUserScripts":
       // TODO: The onMessage method should be able to return a value, but does not do so because of a bug.
       //  More info: https://github.com/mozilla/webextension-polyfill/issues/172
-      try {
-        browser.runtime
-          .sendMessage({
-            type: "resolveAddUserScripts",
-            scripts: await manager.addUserScripts(request.scripts),
-          })
-          .then();
-      } catch {
-        // If tab is closed, message goes nowhere and an error occurs. Ignore.
-      }
+      browser.runtime
+        .sendMessage({
+          type: "resolveAddUserScripts",
+          scripts: await manager.addUserScripts(request.scripts),
+        })
+        .then()
+        .catch(() => {}); // If tab is closed, message goes nowhere and an error occurs. Ignore.
       break;
     case "getPluginInfo":
-      try {
-        browser.runtime
-          .sendMessage({
-            type: "resolveGetPluginInfo",
-            info: await manager.getPluginInfo(request.uid),
-          })
-          .then();
-      } catch {
-        // If tab is closed, message goes nowhere and an error occurs. Ignore.
-      }
+      browser.runtime
+        .sendMessage({
+          type: "resolveGetPluginInfo",
+          info: await manager.getPluginInfo(request.uid),
+        })
+        .then()
+        .catch(() => {}); // If tab is closed, message goes nowhere and an error occurs. Ignore.
       break;
     case "getBackupData":
-      try {
-        browser.runtime
-          .sendMessage({
-            type: "resolveGetBackupData",
-            data: await manager.getBackupData(request.params),
-          })
-          .then();
-      } catch {
-        // If tab is closed, message goes nowhere and an error occurs. Ignore.
-      }
+      browser.runtime
+        .sendMessage({
+          type: "resolveGetBackupData",
+          data: await manager.getBackupData(request.params),
+        })
+        .then()
+        .catch(() => {}); // If tab is closed, message goes nowhere and an error occurs. Ignore.
       break;
     case "setBackupData":
-      try {
-        browser.runtime
-          .sendMessage({
-            type: "resolveSetBackupData",
-            data: await manager.setBackupData(
-              request.params,
-              request.backup_data
-            ),
-          })
-          .then();
-      } catch {
-        // If tab is closed, message goes nowhere and an error occurs. Ignore.
-      }
+      browser.runtime
+        .sendMessage({
+          type: "resolveSetBackupData",
+          data: await manager.setBackupData(
+            request.params,
+            request.backup_data
+          ),
+        })
+        .then()
+        .catch(() => {}); // If tab is closed, message goes nowhere and an error occurs. Ignore.
       break;
     case "checkUserScriptsApiAvailable":
-      try {
-        browser.runtime
-          .sendMessage({
-            type: "resolveCheckUserScriptsApiAvailable",
-            data: is_userscripts_api_available(),
-          })
-          .then();
-      } catch {
-        // If tab is closed, message goes nowhere and an error occurs. Ignore.
-      }
+      browser.runtime
+        .sendMessage({
+          type: "resolveCheckUserScriptsApiAvailable",
+          data: is_userscripts_api_available(),
+        })
+        .then()
+        .catch(() => {}); // If tab is closed, message goes nowhere and an error occurs. Ignore.
       break;
     case "setCustomChannelUrl":
       await manager.setCustomChannelUrl(request.value);

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -189,6 +189,7 @@ async function xmlHttpRequestHandler(data) {
 
   try {
     const response = await fetch(data.url, {
+      mode: "no-cors",
       method: data.method,
       headers: data.headers,
       body: data.method !== "GET" ? data.data : undefined,

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -249,11 +249,3 @@ async function manage_user_scripts_status(status) {
     }
   }
 }
-
-self.addEventListener("install", () => {
-  console.log("Service Worker installed");
-});
-
-self.addEventListener("activate", () => {
-  console.log("Service Worker activated");
-});

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -181,3 +181,11 @@ async function xmlHttpRequestHandler(data) {
 
   req.send(data.data);
 }
+
+self.addEventListener("install", () => {
+  console.log("Service Worker installed");
+});
+
+self.addEventListener("activate", () => {
+  console.log("Service Worker activated");
+});

--- a/src/background/injector.js
+++ b/src/background/injector.js
@@ -1,14 +1,9 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
-import {
-  gm_api_for_plugin,
-  is_userscripts_api_available,
-} from "@/userscripts/wrapper";
+import { gm_api_for_plugin } from "@/userscripts/wrapper";
 import { getNiaTabsToInject, getPluginMatches } from "@/background/utils";
-
-// TODO
-// https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users
+import { is_userscripts_api_available } from "@/userscripts/utils";
 
 export async function inject_plugin_via_content_scripts(plugin, use_gm_api) {
   const tabs = await getNiaTabsToInject(plugin);

--- a/src/background/injector.js
+++ b/src/background/injector.js
@@ -1,40 +1,20 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
-import { check_matching } from "lib-iitc-manager";
+import {
+  gm_api_for_plugin,
+  is_userscripts_api_available,
+} from "@/userscripts/wrapper";
+import { getNiaTabsToInject, getPluginMatches } from "@/background/utils";
 
 // TODO
 // https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users
 
-export async function inject_plugin(plugin) {
-  const tabs = await getTabsToInject();
-
-  const is_ingress_tab = (url) => {
-    return /https:\/\/(intel|missions).ingress.com\/*/.test(url);
-  };
-
-  chrome.userScripts.configureWorld({
-    csp: "script-src 'self' 'unsafe-inline'",
-  });
-
-  try {
-    chrome.userScripts.unregister(["iitc"]);
-  } catch (error) {
-    console.log(error);
-  }
-  chrome.userScripts.register([
-    {
-      id: "iitc",
-      matches: ["https://intel.ingress.com/*"],
-      js: [{ code: plugin.code }],
-    },
-  ]);
+export async function inject_plugin_via_content_scripts(plugin, use_gm_api) {
+  const tabs = await getNiaTabsToInject(plugin);
   for (let tab of Object.values(tabs)) {
-    if (
-      (!is_ingress_tab(tab.url) || !check_matching(plugin, "<all_ingress>")) &&
-      !check_matching(plugin, tab.url)
-    ) {
-      continue;
+    if (use_gm_api) {
+      plugin.code = await gm_api_for_plugin(plugin, tab.id);
     }
 
     try {
@@ -58,11 +38,39 @@ export async function inject_plugin(plugin) {
   }
 }
 
-// Fetch all completly loaded Ingress Intel tabs
-export async function getTabsToInject() {
-  let allTabs = await browser.tabs.query({ status: "complete" });
+export async function inject_plugin_via_userscripts_api(plugin, use_gm_api) {
+  if (!is_userscripts_api_available) return;
 
-  return allTabs.filter(function (tab) {
-    return tab.status === "complete" && tab.url;
-  });
+  if (use_gm_api) {
+    plugin.code = await gm_api_for_plugin(plugin, 0);
+  }
+
+  let scripts = [];
+  try {
+    scripts = await chrome.userScripts.getScripts();
+  } catch (e) {
+    console.log(e);
+    return;
+  }
+  const plugin_obj = [
+    {
+      id: plugin.uid,
+      matches:
+        plugin.uid === "gm_api" ? ["https://*/*"] : getPluginMatches(plugin),
+      js: [{ code: plugin.code }],
+      runAt: plugin.uid === "gm_api" ? "document_start" : "document_end",
+      world: "MAIN",
+    },
+  ];
+
+  const is_exist = scripts.some((script) => script.id === plugin.uid);
+  if (!is_exist) {
+    await chrome.userScripts.register(plugin_obj);
+    return;
+  }
+
+  const exist_script = scripts.find((script) => script.id === plugin.uid);
+  if (exist_script.js[0].code !== plugin_obj[0].js[0].code) {
+    await chrome.userScripts.update(plugin_obj);
+  }
 }

--- a/src/background/intel.js
+++ b/src/background/intel.js
@@ -9,7 +9,7 @@ let lastIITCTab = null;
 export async function onRequestOpenIntel() {
   if (lastIITCTab) {
     const tabInfo = await getTabInfo(lastIITCTab);
-    if (isIngressIntelUrl(tabInfo.url)) {
+    if (tabInfo && isIngressIntelUrl(tabInfo.url)) {
       return await setTabActive(lastIITCTab);
     }
   }
@@ -84,7 +84,11 @@ async function setTabActive(tabId) {
 }
 
 async function getTabInfo(tabId) {
-  return await browser.tabs.get(tabId);
+  try {
+    return await browser.tabs.get(tabId);
+  } catch {
+    return null;
+  }
 }
 
 function isIngressIntelUrl(url) {

--- a/src/background/intel.js
+++ b/src/background/intel.js
@@ -1,7 +1,7 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 import browser from "webextension-polyfill";
 import { getTabsToInject } from "@/background/utils";
-import { isIITCEnabled } from "@/userscripts/utils";
+import { is_iitc_enabled } from "@/userscripts/utils";
 
 let lastIITCTab = null;
 
@@ -54,7 +54,7 @@ export function onRemovedListener(tabId) {
 }
 
 async function initialize(manager) {
-  const status = await isIITCEnabled();
+  const status = await is_iitc_enabled();
   if (status) {
     await manager.inject();
   }

--- a/src/background/intel.js
+++ b/src/background/intel.js
@@ -1,6 +1,7 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 import browser from "webextension-polyfill";
-import { getTabsToInject } from "./injector";
+import { getTabsToInject } from "@/background/utils";
+import { isIITCEnabled } from "@/userscripts/utils";
 
 let lastIITCTab = null;
 
@@ -53,10 +54,8 @@ export function onRemovedListener(tabId) {
 }
 
 async function initialize(manager) {
-  const storage = await browser.storage.local.get(["IITC_is_enabled"]);
-  const status = storage["IITC_is_enabled"];
-
-  if (status !== false) {
+  const status = await isIITCEnabled();
+  if (status) {
     await manager.inject();
   }
 }

--- a/src/background/requests.js
+++ b/src/background/requests.js
@@ -1,158 +1,103 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
-import { parseMeta, ajaxGet, getUniqId } from "lib-iitc-manager";
-import { isIITCEnabled } from "@/userscripts/utils";
-
-const IS_CHROME = !!global.chrome.app;
-const whitelist = [
-  "^https://github.com/[^/]*/[^/]*/raw/[^/]*/[^/]*?\\.user\\.js([?#]|$)",
-  "^https://gist.github.com/.*?/[^/]*?.user.js([?#]|$)",
-  "^https://gitlab.com/[^/]*/[^/]*/(|-/)raw/[^/]*/[^/]*?\\.user\\.js([?#]|$)",
-].map((re) => new RegExp(re));
-const blacklist = ["//(?:(?:gist.|)github.com|gitlab.com)/"].map(
-  (re) => new RegExp(re)
-);
-
-const cache = {};
 
 /**
- * If the URL looks like an IITC plugin and the bypass flag is not set,
- * it stops the download and triggers an in-depth check of the plugin.
+ * If the URL looks like an IITC plugin, saving the URL to the cache
  *
  * @param {Object} req - webRequest.onBeforeRequest object.
- * @return {Object}
  */
 export function onBeforeRequest(req) {
-  const { method, tabId, url } = req;
+  const { tabId, url } = req;
 
-  if (tabId in cache && cache[tabId] === "bypass") {
-    delete cache[tabId];
-    return {};
-  }
-  if (method !== "GET") {
-    return;
-  }
-
-  if (!blacklist.some(matches, url) || whitelist.some(matches, url)) {
-    maybeInstallUserJs(tabId, url).then();
-    return IS_CHROME
-      ? { redirectUrl: "javascript:void 0" } // eslint-disable-line no-script-url
-      : { cancel: true }; // for sites with strict CSP in FF
-  }
+  const cache = {
+    last_userscript_request: {
+      tabId: tabId,
+      url: url,
+    },
+  };
+  browser.storage.local.set(cache).then();
 }
 
-/**
- * Writes the tab ID into the cache so that it does not interact with the tab later on and restarts the request.
- *
- * @param {Number} tabId - Tab ID.
- * @param {String} url - Requested URL.
- * @return {Promise<void>}
- */
-async function bypass(tabId, url) {
-  if (tabId < 0) return;
-  cache[tabId] = "bypass";
-  await browser.tabs.update(tabId, { url });
-}
-
-/**
- * Checks the URL for availability of the IITC plugin.
- * Closes the tab if the URL was opened in a new tab.
- * If the URL is not an IITC plugin, causes the URL to reopen without further extension intervention.
- *
- * @async
- * @param {Number} tabId - Tab ID.
- * @param {String} url - Requested URL.
- * @return {Promise<void>}
- */
-async function maybeInstallUserJs(tabId, url) {
-  const status = await isIITCEnabled();
-  if (status === false) {
-    await bypass(tabId, url);
-    return;
-  }
-
-  let code = undefined;
-  try {
-    code = await ajaxGet(url);
-  } catch {
-    await bypass(tabId, url);
-  }
-
-  if (!code) await bypass(tabId, url);
-  const meta = parseMeta(code);
-
-  if (meta.name) {
-    if (tabId in cache && cache[tabId] === "autoclose") {
-      browser.tabs.remove(tabId).then();
-    }
-    await confirmInstall(url, code);
-  } else {
-    await bypass(tabId, url);
-  }
-}
-
-/**
- * Creating a tab with plugin installation.
- *
- * @async
- * @param {String} url - URL of the plugin.
- * @param {String} code - Plugin code.
- * @return {Promise<void>}
- */
-async function confirmInstall(url, code) {
-  const cache = {};
-  const uniqId = getUniqId("tmp");
-  cache[uniqId] = { url: url, code: code };
-  await browser.storage.local.set(cache);
-
-  await browser.tabs.create({
-    url: await browser.runtime.getURL(`/jsview.html?uniqId=${uniqId}`),
+if (browser.webRequest) {
+  browser.webRequest.onBeforeRequest.addListener(onBeforeRequest, {
+    urls: [
+      // 1. *:// comprises only http/https
+      // 2. the API ignores #hash part
+      // 3. Firefox: onBeforeRequest does not work with file:// or moz-extension://
+      "*://*/*.user.js",
+      "*://*/*.user.js?*",
+      "file://*/*.user.js",
+      "file://*/*.user.js?*",
+    ],
+    types: ["main_frame"],
   });
 }
 
-/** @this {string} */
-function matches(re) {
-  return re.test(this);
-}
+browser.runtime.onInstalled.addListener(async function () {
+  // restore the default rule if the extension is installed or updated
+  const existingRules = await browser.declarativeNetRequest.getDynamicRules();
 
-/**
- * Set autoclose if userscript was opened in a new tab
- */
-browser.tabs.onCreated.addListener((tab) => {
-  const url =
-    tab.url === "about:blank" ? tab.title : tab.url || tab.pendingUrl || "";
-  if (
-    (/\.user\.js([?#]|$)/.test(url) || (url === "" && IS_CHROME)) &&
-    (!blacklist.some(matches, url) || whitelist.some(matches, url))
-  ) {
-    cache[tab.id] = "autoclose";
-  }
+  const jsview_url = await browser.runtime.getURL(`/jsview.html`);
+  browser.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds: existingRules.map((rule) => rule.id),
+    addRules: [
+      {
+        id: 1,
+        priority: 10,
+        action: {
+          type: "allow",
+        },
+        condition: {
+          urlFilter: "|*.user.js*#pass|",
+          resourceTypes: ["main_frame"],
+        },
+      },
+      {
+        id: 2,
+        priority: 2,
+        action: {
+          type: "redirect",
+          redirect: {
+            url: jsview_url,
+          },
+        },
+        condition: {
+          urlFilter: "||github.com/*/*/raw/*/*.user.js",
+          requestDomains: ["github.com"],
+          resourceTypes: ["main_frame"],
+        },
+      },
+      {
+        id: 3,
+        priority: 2,
+        action: {
+          type: "redirect",
+          redirect: {
+            url: jsview_url,
+          },
+        },
+        condition: {
+          urlFilter: "||gitlab.com/*/*/-/raw/*/*.user.js",
+          requestDomains: ["gitlab.com"],
+          resourceTypes: ["main_frame"],
+        },
+      },
+      {
+        id: 4,
+        priority: 1,
+        action: {
+          type: "redirect",
+          redirect: {
+            url: jsview_url,
+          },
+        },
+        condition: {
+          urlFilter: "|*.user.js^",
+          excludedRequestDomains: ["github.com", "gitlab.com"],
+          resourceTypes: ["main_frame"],
+        },
+      },
+    ],
+  });
 });
-
-/**
- * Deleting status when closing a tab
- */
-browser.tabs.onRemoved.addListener((tabId) => {
-  delete cache[tabId];
-});
-
-// Seems unable to access browser.webRequest in Safari in non-persistent background
-if (browser.webRequest) {
-  browser.webRequest.onBeforeRequest.addListener(
-    onBeforeRequest,
-    {
-      urls: [
-        // 1. *:// comprises only http/https
-        // 2. the API ignores #hash part
-        // 3. Firefox: onBeforeRequest does not work with file:// or moz-extension://
-        "*://*/*.user.js",
-        "*://*/*.user.js?*",
-        "file://*/*.user.js",
-        "file://*/*.user.js?*",
-      ],
-      types: ["main_frame"],
-    },
-    ["blocking"]
-  );
-}

--- a/src/background/requests.js
+++ b/src/background/requests.js
@@ -76,75 +76,75 @@ if (browser.webRequest) {
   );
 }
 
-browser.runtime.onInstalled.addListener(async function () {
-  if (!IS_USERSCRIPTS_API) return;
+if (browser.declarativeNetRequest) {
+  browser.runtime.onInstalled.addListener(async function () {
+    // restore the default rule if the extension is installed or updated
+    const existingRules = await browser.declarativeNetRequest.getDynamicRules();
 
-  // restore the default rule if the extension is installed or updated
-  const existingRules = await browser.declarativeNetRequest.getDynamicRules();
-
-  const jsview_url = await browser.runtime.getURL(`/jsview.html`);
-  browser.declarativeNetRequest.updateDynamicRules({
-    removeRuleIds: existingRules.map((rule) => rule.id),
-    addRules: [
-      {
-        id: 1,
-        priority: 10,
-        action: {
-          type: "allow",
-        },
-        condition: {
-          urlFilter: "|*.user.js*#pass|",
-          resourceTypes: ["main_frame"],
-        },
-      },
-      {
-        id: 2,
-        priority: 2,
-        action: {
-          type: "redirect",
-          redirect: {
-            url: jsview_url,
+    const jsview_url = await browser.runtime.getURL(`/jsview.html`);
+    browser.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: existingRules.map((rule) => rule.id),
+      addRules: [
+        {
+          id: 1,
+          priority: 10,
+          action: {
+            type: "allow",
+          },
+          condition: {
+            urlFilter: "|*.user.js*#pass|",
+            resourceTypes: ["main_frame"],
           },
         },
-        condition: {
-          urlFilter: "||github.com/*/*/raw/*/*.user.js",
-          requestDomains: ["github.com"],
-          resourceTypes: ["main_frame"],
-        },
-      },
-      {
-        id: 3,
-        priority: 2,
-        action: {
-          type: "redirect",
-          redirect: {
-            url: jsview_url,
+        {
+          id: 2,
+          priority: 2,
+          action: {
+            type: "redirect",
+            redirect: {
+              url: jsview_url,
+            },
+          },
+          condition: {
+            urlFilter: "||github.com/*/*/raw/*/*.user.js",
+            requestDomains: ["github.com"],
+            resourceTypes: ["main_frame"],
           },
         },
-        condition: {
-          urlFilter: "||gitlab.com/*/*/-/raw/*/*.user.js",
-          requestDomains: ["gitlab.com"],
-          resourceTypes: ["main_frame"],
-        },
-      },
-      {
-        id: 4,
-        priority: 1,
-        action: {
-          type: "redirect",
-          redirect: {
-            url: jsview_url,
+        {
+          id: 3,
+          priority: 2,
+          action: {
+            type: "redirect",
+            redirect: {
+              url: jsview_url,
+            },
+          },
+          condition: {
+            urlFilter: "||gitlab.com/*/*/-/raw/*/*.user.js",
+            requestDomains: ["gitlab.com"],
+            resourceTypes: ["main_frame"],
           },
         },
-        condition: {
-          urlFilter: "|*.user.js^",
-          excludedRequestDomains: ["github.com", "gitlab.com"],
-          resourceTypes: ["main_frame"],
+        {
+          id: 4,
+          priority: 1,
+          action: {
+            type: "redirect",
+            redirect: {
+              url: jsview_url,
+            },
+          },
+          condition: {
+            urlFilter: "|*.user.js^",
+            excludedRequestDomains: ["github.com", "gitlab.com"],
+            resourceTypes: ["main_frame"],
+          },
         },
-      },
-    ],
+      ],
+    });
   });
-});
+}
 
 /**
  * Writes the tab ID into the cache so that it does not interact with the tab later on and restarts the request.

--- a/src/background/requests.js
+++ b/src/background/requests.js
@@ -1,42 +1,83 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
-import { IS_SCRIPTING_API } from "@/userscripts/env";
+import { IS_USERSCRIPTS_API } from "@/userscripts/env";
+import { parseMeta, ajaxGet, getUniqId } from "lib-iitc-manager";
+
+const IS_CHROME = !!global.chrome.app;
+const whitelist = [
+  "^https://github.com/[^/]*/[^/]*/raw/[^/]*/[^/]*?\\.user\\.js([?#]|$)",
+  "^https://gist.github.com/.*?/[^/]*?.user.js([?#]|$)",
+  "^https://gitlab.com/[^/]*/[^/]*/(|-/)raw/[^/]*/[^/]*?\\.user\\.js([?#]|$)",
+].map((re) => new RegExp(re));
+const blacklist = ["//(?:(?:gist.|)github.com|gitlab.com)/"].map(
+  (re) => new RegExp(re)
+);
+
+const cache = {};
 
 /**
+ * webRequest:
  * If the URL looks like an IITC plugin, saving the URL to the cache
  *
+ * webRequestBlocking:
+ * If the URL looks like an IITC plugin and the bypass flag is not set,
+ * it stops the download and triggers an in-depth check of the plugin.
+ *
  * @param {Object} req - webRequest.onBeforeRequest object.
+ * @return {Object|void} - Returns an object if webRequestBlocking mode
  */
 export function onBeforeRequest(req) {
-  const { tabId, url } = req;
+  const { method, tabId, url } = req;
 
-  const cache = {
-    last_userscript_request: {
-      tabId: tabId,
-      url: url,
-    },
-  };
-  browser.storage.local.set(cache).then();
+  if (IS_USERSCRIPTS_API) {
+    const cache = {
+      last_userscript_request: {
+        tabId: tabId,
+        url: url,
+      },
+    };
+    browser.storage.local.set(cache).then();
+  } else {
+    if (tabId in cache && cache[tabId] === "bypass") {
+      delete cache[tabId];
+      return {};
+    }
+    if (method !== "GET") {
+      return;
+    }
+
+    if (!blacklist.some(matches, url) || whitelist.some(matches, url)) {
+      maybeInstallUserJs(tabId, url).then();
+      return IS_CHROME
+        ? { redirectUrl: "javascript:void 0" } // eslint-disable-line no-script-url
+        : { cancel: true }; // for sites with strict CSP in FF
+    }
+  }
 }
 
 if (browser.webRequest) {
-  browser.webRequest.onBeforeRequest.addListener(onBeforeRequest, {
-    urls: [
-      // 1. *:// comprises only http/https
-      // 2. the API ignores #hash part
-      // 3. Firefox: onBeforeRequest does not work with file:// or moz-extension://
-      "*://*/*.user.js",
-      "*://*/*.user.js?*",
-      "file://*/*.user.js",
-      "file://*/*.user.js?*",
-    ],
-    types: ["main_frame"],
-  });
+  const extraInfoSpec = !IS_USERSCRIPTS_API ? ["blocking"] : [];
+  browser.webRequest.onBeforeRequest.addListener(
+    onBeforeRequest,
+    {
+      urls: [
+        // 1. *:// comprises only http/https
+        // 2. the API ignores #hash part
+        // 3. Firefox: onBeforeRequest does not work with file:// or moz-extension://
+        "*://*/*.user.js",
+        "*://*/*.user.js?*",
+        "file://*/*.user.js",
+        "file://*/*.user.js?*",
+      ],
+      types: ["main_frame"],
+    },
+    extraInfoSpec
+  );
 }
 
 browser.runtime.onInstalled.addListener(async function () {
-  if (IS_SCRIPTING_API) return;
+  if (!IS_USERSCRIPTS_API) return;
 
   // restore the default rule if the extension is installed or updated
   const existingRules = await browser.declarativeNetRequest.getDynamicRules();
@@ -103,4 +144,101 @@ browser.runtime.onInstalled.addListener(async function () {
       },
     ],
   });
+});
+
+/**
+ * Writes the tab ID into the cache so that it does not interact with the tab later on and restarts the request.
+ *
+ * @param {Number} tabId - Tab ID.
+ * @param {String} url - Requested URL.
+ * @return {Promise<void>}
+ */
+async function bypass(tabId, url) {
+  if (tabId < 0) return;
+  cache[tabId] = "bypass";
+  await browser.tabs.update(tabId, { url });
+}
+
+/**
+ * Checks the URL for availability of the IITC plugin.
+ * Closes the tab if the URL was opened in a new tab.
+ * If the URL is not an IITC plugin, causes the URL to reopen without further extension intervention.
+ *
+ * @async
+ * @param {Number} tabId - Tab ID.
+ * @param {String} url - Requested URL.
+ * @return {Promise<void>}
+ */
+async function maybeInstallUserJs(tabId, url) {
+  const IITC_is_enabled = await browser.storage.local
+    .get(["IITC_is_enabled"])
+    .then((data) => data.IITC_is_enabled);
+  if (IITC_is_enabled === false) {
+    await bypass(tabId, url);
+    return;
+  }
+
+  let code = undefined;
+  try {
+    code = await ajaxGet(url);
+  } catch {
+    await bypass(tabId, url);
+  }
+
+  if (!code) await bypass(tabId, url);
+  const meta = parseMeta(code);
+
+  if (meta.name) {
+    if (tabId in cache && cache[tabId] === "autoclose") {
+      browser.tabs.remove(tabId).then();
+    }
+    await confirmInstall(url, code);
+  } else {
+    await bypass(tabId, url);
+  }
+}
+
+/**
+ * Creating a tab with plugin installation.
+ *
+ * @async
+ * @param {String} url - URL of the plugin.
+ * @param {String} code - Plugin code.
+ * @return {Promise<void>}
+ */
+async function confirmInstall(url, code) {
+  const cache = {};
+  const uniqId = getUniqId("tmp");
+  cache[uniqId] = { url: url, code: code };
+  await browser.storage.local.set(cache);
+
+  await browser.tabs.create({
+    url: await browser.runtime.getURL(`/jsview.html?uniqId=${uniqId}`),
+  });
+}
+
+/** @this {string} */
+function matches(re) {
+  return re.test(this);
+}
+
+/**
+ * Set autoclose if userscript was opened in a new tab
+ */
+browser.tabs.onCreated.addListener((tab) => {
+  const url =
+    tab.url === "about:blank" ? tab.title : tab.url || tab.pendingUrl || "";
+  if (
+    (/\.user\.js([?#]|$)/.test(url) || (url === "" && IS_CHROME)) &&
+    (!blacklist.some(matches, url) || whitelist.some(matches, url))
+  ) {
+    cache[tab.id] = "autoclose";
+  }
+});
+
+/**
+ * Deleting status when closing a tab
+ */
+browser.tabs.onRemoved.addListener((tabId) => {
+  delete cache[tabId];
 });

--- a/src/background/requests.js
+++ b/src/background/requests.js
@@ -31,13 +31,13 @@ export function onBeforeRequest(req) {
   const { method, tabId, url } = req;
 
   if (IS_USERSCRIPTS_API) {
-    const cache = {
+    const local_cache = {
       last_userscript_request: {
         tabId: tabId,
         url: url,
       },
     };
-    browser.storage.local.set(cache).then();
+    browser.storage.local.set(local_cache).then();
   } else {
     if (tabId in cache && cache[tabId] === "bypass") {
       delete cache[tabId];

--- a/src/background/requests.js
+++ b/src/background/requests.js
@@ -2,6 +2,7 @@
 
 import browser from "webextension-polyfill";
 import { parseMeta, ajaxGet, getUniqId } from "lib-iitc-manager";
+import { isIITCEnabled } from "@/userscripts/utils";
 
 const IS_CHROME = !!global.chrome.app;
 const whitelist = [
@@ -65,10 +66,8 @@ async function bypass(tabId, url) {
  * @return {Promise<void>}
  */
 async function maybeInstallUserJs(tabId, url) {
-  const IITC_is_enabled = await browser.storage.local
-    .get(["IITC_is_enabled"])
-    .then((data) => data.IITC_is_enabled);
-  if (IITC_is_enabled === false) {
+  const status = await isIITCEnabled();
+  if (status === false) {
     await bypass(tabId, url);
     return;
   }

--- a/src/background/requests.js
+++ b/src/background/requests.js
@@ -1,6 +1,7 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
+import { IS_SCRIPTING_API } from "@/userscripts/env";
 
 /**
  * If the URL looks like an IITC plugin, saving the URL to the cache
@@ -35,6 +36,8 @@ if (browser.webRequest) {
 }
 
 browser.runtime.onInstalled.addListener(async function () {
+  if (IS_SCRIPTING_API) return;
+
   // restore the default rule if the extension is installed or updated
   const existingRules = await browser.declarativeNetRequest.getDynamicRules();
 

--- a/src/background/utils.js
+++ b/src/background/utils.js
@@ -1,0 +1,38 @@
+//@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+
+import browser from "webextension-polyfill";
+import { check_matching } from "lib-iitc-manager";
+
+const is_ingress_tab = (url) => {
+  return /https:\/\/(intel|missions).ingress.com\/*/.test(url);
+};
+
+// Fetch all completly loaded tabs
+export async function getTabsToInject() {
+  let allTabs = await browser.tabs.query({ status: "complete" });
+  return allTabs.filter(function (tab) {
+    return tab.status === "complete" && tab.url;
+  });
+}
+
+// Filter all completly loaded Ingress Intel tabs
+export async function getNiaTabsToInject(plugin) {
+  const tabs = await getTabsToInject();
+  return Object.values(tabs).filter(
+    (tab) =>
+      (is_ingress_tab(tab.url) && check_matching(plugin, "<all_ingress>")) ||
+      check_matching(plugin, tab.url)
+  );
+}
+
+export function getPluginMatches(plugin) {
+  let matches = [];
+  if (check_matching(plugin, "<all_ingress>")) {
+    matches.push("https://intel.ingress.com/*");
+    matches.push("https://missions.ingress.com/*");
+  }
+  if (plugin.match) {
+    matches = matches.concat(plugin.match);
+  }
+  return matches;
+}

--- a/src/content-scripts/bridge.js
+++ b/src/content-scripts/bridge.js
@@ -1,6 +1,7 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
+import { IS_USERSCRIPTS_API } from "@/userscripts/env";
 import { inject } from "@/content-scripts/utils";
 import { strToBase64 } from "@/strToBase64";
 
@@ -34,6 +35,14 @@ const xmlResponseBridge = async (data) => {
     .then();
 };
 
+browser.runtime.onMessage.addListener(async (request) => {
+  switch (request.type) {
+    case "xmlHttpRequestToCS":
+      bridgeResponse(request.value);
+      break;
+  }
+});
+
 // Sends the entire plugins scoped storage to the page context
 const getStorageBridge = async (req) => {
   const all_storage = await browser.storage.local.get(null);
@@ -48,12 +57,8 @@ const getStorageBridge = async (req) => {
     response: JSON.stringify(plugins_storage),
   });
 
-  const injectedCode = `
-    document.dispatchEvent(new CustomEvent('bridgeResponse', {
-      detail: "${strToBase64(String(detail_stringify))}"
-    }));
-  `;
-  inject(injectedCode);
+  const bridge_base64_data = strToBase64(String(detail_stringify));
+  bridgeResponse(bridge_base64_data);
 };
 
 // Saves the value in the persistent storage in order to synchronize the data with the storage in the page context
@@ -66,4 +71,21 @@ const setValueBridge = async (req) => {
 // Deletes the value in the persistent storage in order to synchronize the data with the storage in the page context
 const delValueBridge = async (req) => {
   await browser.storage.local.remove(req.key);
+};
+
+const bridgeResponse = (bridge_base64_data) => {
+  if (IS_USERSCRIPTS_API) {
+    dispatchEvent(
+      new CustomEvent("bridgeResponse", {
+        detail: bridge_base64_data,
+      })
+    );
+  } else {
+    const injectedCode = `
+    document.dispatchEvent(new CustomEvent('bridgeResponse', {
+      detail: "${bridge_base64_data}"
+    }));
+  `;
+    inject(injectedCode);
+  }
 };

--- a/src/content-scripts/bridge.js
+++ b/src/content-scripts/bridge.js
@@ -2,6 +2,7 @@
 
 import browser from "webextension-polyfill";
 import { strToBase64 } from "@/strToBase64";
+import { isRunContentScript } from "@/content-scripts/utils";
 
 export async function bridgeAction(e) {
   const task = e.detail;
@@ -33,13 +34,15 @@ const xmlResponseBridge = async (data) => {
     .then();
 };
 
-browser.runtime.onMessage.addListener(async (request) => {
-  switch (request.type) {
-    case "xmlHttpRequestToCS":
-      bridgeResponse(request.value);
-      break;
-  }
-});
+if (isRunContentScript) {
+  browser.runtime.onMessage.addListener(async (request) => {
+    switch (request.type) {
+      case "xmlHttpRequestToCS":
+        bridgeResponse(request.value);
+        break;
+    }
+  });
+}
 
 // Sends the entire plugins scoped storage to the page context
 const getStorageBridge = async (req) => {

--- a/src/content-scripts/bridge.js
+++ b/src/content-scripts/bridge.js
@@ -1,8 +1,6 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
-import { IS_USERSCRIPTS_API } from "@/userscripts/env";
-import { inject } from "@/content-scripts/utils";
 import { strToBase64 } from "@/strToBase64";
 
 export async function bridgeAction(e) {
@@ -74,18 +72,9 @@ const delValueBridge = async (req) => {
 };
 
 const bridgeResponse = (bridge_base64_data) => {
-  if (IS_USERSCRIPTS_API) {
-    dispatchEvent(
-      new CustomEvent("bridgeResponse", {
-        detail: bridge_base64_data,
-      })
-    );
-  } else {
-    const injectedCode = `
-    document.dispatchEvent(new CustomEvent('bridgeResponse', {
-      detail: "${bridge_base64_data}"
-    }));
-  `;
-    inject(injectedCode);
-  }
+  dispatchEvent(
+    new CustomEvent("bridgeResponse", {
+      detail: bridge_base64_data,
+    })
+  );
 };

--- a/src/content-scripts/loader.js
+++ b/src/content-scripts/loader.js
@@ -4,7 +4,7 @@ import { IITCButtonInitJS } from "./utils";
 import { bridgeAction } from "@/content-scripts/bridge";
 import { inject_gm_api } from "@/userscripts/wrapper";
 import { IS_USERSCRIPTS_API } from "@/userscripts/env";
-import { isIITCEnabled } from "@/userscripts/utils";
+import { is_iitc_enabled } from "@/userscripts/utils";
 
 function preparePage() {
   document.addEventListener("bridgeRequest", bridgeAction);
@@ -14,7 +14,7 @@ function preparePage() {
   document.addEventListener("IITCButtonInitJS", IITCButtonInitJS);
 }
 
-isIITCEnabled().then((status) => {
+is_iitc_enabled().then((status) => {
   if (status) {
     preparePage();
   }

--- a/src/content-scripts/loader.js
+++ b/src/content-scripts/loader.js
@@ -1,29 +1,21 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
-import browser from "webextension-polyfill";
-import { GM } from "./gm-api";
-import { inject, IITCButtonInitJS } from "./utils";
+import { IITCButtonInitJS } from "./utils";
 import { bridgeAction } from "@/content-scripts/bridge";
+import { inject_gm_api } from "@/userscripts/wrapper";
+import { IS_USERSCRIPTS_API } from "@/userscripts/env";
+import { isIITCEnabled } from "@/userscripts/utils";
 
 function preparePage() {
-  document.addEventListener("DOMContentLoaded", function () {
-    if (window.location.hostname === "intel.ingress.com") {
-      window.onload = function () {};
-      document.body.onload = function () {};
-    }
-  });
-
-  inject(
-    `((${GM.toString()}))()\n//# sourceURL=${browser.runtime.getURL(
-      "js/GM_api.js"
-    )}`
-  );
   document.addEventListener("bridgeRequest", bridgeAction);
+  if (IS_USERSCRIPTS_API) return;
+
+  inject_gm_api();
   document.addEventListener("IITCButtonInitJS", IITCButtonInitJS);
 }
 
-browser.storage.local.get(["IITC_is_enabled"]).then((data) => {
-  if (data["IITC_is_enabled"] !== false) {
+isIITCEnabled().then((status) => {
+  if (status) {
     preparePage();
   }
 });

--- a/src/content-scripts/loader.js
+++ b/src/content-scripts/loader.js
@@ -1,6 +1,6 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
-import { IITCButtonInitJS } from "./utils";
+import { IITCButtonInitJS, isRunContentScript } from "./utils";
 import { bridgeAction } from "@/content-scripts/bridge";
 import { inject_gm_api } from "@/userscripts/wrapper";
 import { IS_USERSCRIPTS_API } from "@/userscripts/env";
@@ -14,8 +14,11 @@ function preparePage() {
   document.addEventListener("IITCButtonInitJS", IITCButtonInitJS);
 }
 
-is_iitc_enabled().then((status) => {
-  if (status) {
-    preparePage();
-  }
-});
+if (isRunContentScript) {
+  window.iitcbutton = true;
+  is_iitc_enabled().then((status) => {
+    if (status) {
+      preparePage();
+    }
+  });
+}

--- a/src/content-scripts/utils.js
+++ b/src/content-scripts/utils.js
@@ -7,12 +7,13 @@ import { strToBase64 } from "@/strToBase64";
 const LOADED_PLUGINS = [];
 
 export function inject(code) {
-  const script = document.createElement("script");
-  script.appendChild(document.createTextNode(code));
-  (document.body || document.head || document.documentElement).appendChild(
-    script
-  );
-  script.parentElement.removeChild(script);
+  // const script = document.createElement("script");
+  // script.appendChild(document.createTextNode(code));
+  // (document.body || document.head || document.documentElement).appendChild(
+  //   script
+  // );
+  // script.parentElement.removeChild(script);
+  console.log(code[0]);
 }
 
 function getPluginHash(uid) {

--- a/src/content-scripts/utils.js
+++ b/src/content-scripts/utils.js
@@ -4,6 +4,8 @@ import { getUID } from "lib-iitc-manager";
 
 const LOADED_PLUGINS = [];
 
+export const isRunContentScript = !window.iitcbutton;
+
 export function inject(code) {
   const script = document.createElement("script");
   script.appendChild(document.createTextNode(code));

--- a/src/content-scripts/utils.js
+++ b/src/content-scripts/utils.js
@@ -1,7 +1,6 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import { getUID } from "lib-iitc-manager";
-import { gm_api_for_plugin } from "@/userscripts/wrapper";
 
 const LOADED_PLUGINS = [];
 
@@ -15,7 +14,6 @@ export function inject(code) {
 }
 
 export async function IITCButtonInitJS(e) {
-  const tab_id = e.detail.tab_id;
   const plugin = e.detail.plugin;
 
   const uid = plugin.uid ? plugin.uid : getUID(plugin);
@@ -24,8 +22,6 @@ export async function IITCButtonInitJS(e) {
   } else {
     LOADED_PLUGINS.push(uid);
     console.debug(`Plugin ${uid} loaded`);
-
-    const code = gm_api_for_plugin(plugin, tab_id);
-    inject(code);
+    inject(plugin.code);
   }
 }

--- a/src/content-scripts/utils.js
+++ b/src/content-scripts/utils.js
@@ -1,61 +1,31 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
-import browser from "webextension-polyfill";
 import { getUID } from "lib-iitc-manager";
-import { strToBase64 } from "@/strToBase64";
+import { gm_api_for_plugin } from "@/userscripts/wrapper";
 
 const LOADED_PLUGINS = [];
 
 export function inject(code) {
-  // const script = document.createElement("script");
-  // script.appendChild(document.createTextNode(code));
-  // (document.body || document.head || document.documentElement).appendChild(
-  //   script
-  // );
-  // script.parentElement.removeChild(script);
-  console.log(code[0]);
-}
-
-function getPluginHash(uid) {
-  return "VMin" + strToBase64(uid);
+  const script = document.createElement("script");
+  script.appendChild(document.createTextNode(code));
+  (document.body || document.head || document.documentElement).appendChild(
+    script
+  );
+  script.parentElement.removeChild(script);
 }
 
 export async function IITCButtonInitJS(e) {
   const tab_id = e.detail.tab_id;
   const plugin = e.detail.plugin;
 
-  const meta = { ...plugin };
-  delete meta.code;
-
   const uid = plugin.uid ? plugin.uid : getUID(plugin);
-  let data_key = getPluginHash(uid);
   if (LOADED_PLUGINS.includes(uid)) {
     console.debug(`Plugin ${uid} is already loaded. Skip`);
   } else {
     LOADED_PLUGINS.push(uid);
     console.debug(`Plugin ${uid} loaded`);
 
-    const name = encodeURIComponent(plugin.name);
-    const injectedCode = [
-      "((GM)=>{",
-      // an implementation of GM API v3 based on GM API v4
-      "const GM_info = GM.info; const unsafeWindow = window;",
-      "const exportFunction = GM.exportFunction; const createObjectIn = GM.createObjectIn; const cloneInto = GM.cloneInto;",
-      "const GM_getValue = (key, value) => GM._getValueSync(key, value);",
-      "const GM_setValue = (key, value) => GM._setValueSync(key, value);",
-      "const GM_xmlhttpRequest = (details) => GM.xmlHttpRequest(details);",
-
-      plugin.code,
-      // adding a new line in case the code ends with a line comment
-      plugin.code.endsWith("\n") ? "" : "\n",
-      `})(GM("${data_key}", ${tab_id}, ${JSON.stringify(meta)}))`,
-
-      // Firefox lists .user.js among our own content scripts so a space at start will group them
-      `\n//# sourceURL=${browser.runtime.getURL(
-        "plugins/%20" + name + ".user.js"
-      )}`,
-    ].join("");
-
-    inject(injectedCode);
+    const code = gm_api_for_plugin(plugin, tab_id);
+    inject(code);
   }
 }

--- a/src/jsview/App.vue
+++ b/src/jsview/App.vue
@@ -7,9 +7,11 @@
 </template>
 
 <script>
+import browser from "webextension-polyfill";
 import Code from "./Code";
 import { _ } from "@/i18n";
 import Header from "./Header";
+import { ajaxGet } from "lib-iitc-manager";
 import { parseMeta } from "lib-iitc-manager";
 
 export default {
@@ -27,17 +29,33 @@ export default {
   },
   methods: {
     _: _,
+    bypass: async function (tabId, url) {
+      await browser.tabs.create({
+        url: `${url}#pass`,
+      });
+      await browser.tabs.remove(tabId);
+    },
   },
   async mounted() {
-    const uniqId = new URL(window.location.href).searchParams.get("uniqId");
-    const data = await browser.storage.local.get(uniqId);
-    const { url, code } = data[uniqId];
-    await browser.storage.local.remove(uniqId);
+    const last_userscript_request = await browser.storage.local
+      .get("last_userscript_request")
+      .then((d) => d.last_userscript_request);
+    const tabId = last_userscript_request["tabId"];
+    const url = last_userscript_request["url"];
+
+    let code = undefined;
+    try {
+      code = await ajaxGet(url);
+    } catch {
+      return await this.bypass(tabId, url);
+    }
 
     const meta = parseMeta(code);
-    if (meta["name"] === undefined) return;
-    document.title = `${meta["name"]} — ${_("jsViewTitle")} — IITC Button`;
+    if (meta === null || !("name" in meta) || meta.name === undefined) {
+      return await this.bypass(tabId, url);
+    }
 
+    document.title = `${meta["name"]} — ${_("jsViewTitle")} — IITC Button`;
     meta["filename"] = url.substr(url.lastIndexOf("/") + 1);
     this.meta = meta;
     this.code = code;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "IITC Button",
   "description": "__MSG_extDescription__",
-  "minimum_chrome_version": "120",
+  "minimum_chrome_version": "61",
   "browser_specific_settings": {
     "gecko": {
       "id": "iitc@modos189.ru",
@@ -14,31 +14,11 @@
   "permissions": [
     "tabs",
     "storage",
-    "scripting",
-    "webRequest",
-    "userScripts",
     "unlimitedStorage"
   ],
-  "host_permissions": [
-    "https://intel.ingress.com/*"
-  ],
-  "optional_host_permissions":[
-    "https://*/*",
-    "http://*/*"
-  ],
-
   "default_locale": "en",
-  "background": {
-    "service_worker": "js/background.js"
-  },
-  "content_scripts": [
-    {
-      "matches" : ["<all_urls>"],
-      "run_at": "document_start",
-      "js": ["js/content-script.js"]
-    }
-  ],
-  "action": {
+  "background": {},
+  "browser_action": {
     "default_popup": "popup.html",
     "default_title": "__MSG_titleDefault__",
     "default_icon": {
@@ -49,9 +29,5 @@
   "icons": {
     "48": "assets/icons/48/icon.png",
     "128": "assets/icons/128/icon.png"
-  },
-  "content_security_policy": {
-    "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws://localhost:9090 http://localhost:8000 https://github.com https://iitc.app; img-src 'self' https://iitc.app"
-  },
-  "manifest_version": 3
+  }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "IITC Button",
   "description": "__MSG_extDescription__",
-  "minimum_chrome_version": "61",
+  "minimum_chrome_version": "120",
   "browser_specific_settings": {
     "gecko": {
       "id": "iitc@modos189.ru",
@@ -14,14 +14,22 @@
   "permissions": [
     "tabs",
     "storage",
-    "<all_urls>",
+    "scripting",
     "webRequest",
-    "webRequestBlocking",
+    "userScripts",
     "unlimitedStorage"
   ],
+  "host_permissions": [
+    "https://intel.ingress.com/*"
+  ],
+  "optional_host_permissions":[
+    "https://*/*",
+    "http://*/*"
+  ],
+
   "default_locale": "en",
   "background": {
-    "page": "background.html"
+    "service_worker": "js/background.js"
   },
   "content_scripts": [
     {
@@ -30,8 +38,7 @@
       "js": ["js/content-script.js"]
     }
   ],
-  "browser_action": {
-    "browser_style": true,
+  "action": {
     "default_popup": "popup.html",
     "default_title": "__MSG_titleDefault__",
     "default_icon": {
@@ -43,5 +50,8 @@
     "48": "assets/icons/48/icon.png",
     "128": "assets/icons/128/icon.png"
   },
-  "manifest_version": 2
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws://localhost:9090 http://localhost:8000 https://github.com https://iitc.app; img-src 'self' https://iitc.app"
+  },
+  "manifest_version": 3
 }

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -34,6 +34,7 @@ import Message from "./components/Message";
 import Alert from "./components/Alert";
 
 import * as data from "./data.js";
+import browser from "webextension-polyfill";
 
 export default {
   name: "App",
@@ -61,6 +62,7 @@ export default {
     await data.init(this);
     await data.onChangedListener(this);
     await data.onMessageListener(this);
+    await browser.runtime.sendMessage({ type: "popupWasOpened" });
   },
   methods: {
     detect_safari: function () {

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -21,6 +21,7 @@
       </SectionPlugins>
     </section>
     <Message></Message>
+    <Alert></Alert>
   </div>
 </template>
 
@@ -30,6 +31,7 @@ import SectionOptions from "./components/SectionOptions.vue";
 import SectionPlugins from "./components/SectionPlugins.vue";
 
 import Message from "./components/Message";
+import Alert from "./components/Alert";
 
 import * as data from "./data.js";
 
@@ -45,7 +47,13 @@ export default {
       is_safari: this.detect_safari(),
     };
   },
-  components: { SectionMainMenu, SectionOptions, SectionPlugins, Message },
+  components: {
+    SectionMainMenu,
+    SectionOptions,
+    SectionPlugins,
+    Message,
+    Alert,
+  },
   beforeCreate() {
     document.body.id = "main-menu";
   },

--- a/src/popup/components/Alert.vue
+++ b/src/popup/components/Alert.vue
@@ -78,10 +78,7 @@ export default {
     requestPermissions: async function requestPermissions(permissions) {
       function onResponse(response) {
         if (response) {
-          console.log("Permission was granted");
           window.close();
-        } else {
-          console.log("Permission was refused");
         }
       }
       const response = await browser.permissions.request(permissions);

--- a/src/popup/components/Alert.vue
+++ b/src/popup/components/Alert.vue
@@ -21,7 +21,7 @@
       ></div>
       <div
         v-on:click="onClickButton('hostPermissionAllUrls')"
-        class="button"
+        class="button hostPermissionAllUrls"
         v-html="_('alertHostPermissionsRequiredButtonAllUrls')"
       ></div>
     </div>
@@ -30,7 +30,7 @@
 
 <script>
 import { mixin } from "./mixins.js";
-import { IS_LEGACY_API, IS_USERSCRIPTS_API } from "@/userscripts/env";
+import { IS_USERSCRIPTS_API } from "@/userscripts/env";
 import browser from "webextension-polyfill";
 
 const intelOrigins = {
@@ -104,7 +104,7 @@ export default {
       }
     });
 
-    if (!IS_LEGACY_API && !(await this.checkHostPermissions())) {
+    if (!(await this.checkHostPermissions())) {
       this.showHostPermissions = true;
     }
   },
@@ -160,5 +160,9 @@ p {
 .button:active,
 .button:focus {
   background: #546e7a;
+}
+
+#app.is_safari .hostPermissionAllUrls {
+  display: none;
 }
 </style>

--- a/src/popup/components/Alert.vue
+++ b/src/popup/components/Alert.vue
@@ -1,0 +1,81 @@
+<!-- @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3 -->
+<template>
+  <div class="bg" v-if="show">
+    <div class="alert">
+      <p v-html="title"></p>
+      <a v-on:click="openLink(button_url)" href="#" v-html="button_title"></a>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mixin } from "./mixins.js";
+import { IS_USERSCRIPTS_API } from "@/userscripts/env";
+import browser from "webextension-polyfill";
+
+export default {
+  name: "Message",
+  mixins: [mixin],
+  data() {
+    return {
+      show: false,
+      title: this._("alertChromeRequiresDevModeTitle"),
+      button_title: this._("alertChromeRequiresDevModeButton"),
+      button_url:
+        "https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users",
+    };
+  },
+  mounted() {
+    if (IS_USERSCRIPTS_API) {
+      browser.runtime
+        .sendMessage({
+          type: "checkUserScriptsApiAvailable",
+        })
+        .then();
+    }
+
+    const self = this;
+    browser.runtime.onMessage.addListener(async function (request) {
+      switch (request.type) {
+        case "resolveCheckUserScriptsApiAvailable":
+          self.$data.show = !request.data;
+          break;
+      }
+    });
+  },
+};
+</script>
+
+<style scoped>
+.bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  background: rgb(0 0 0 / 50%);
+  justify-content: center;
+  align-items: center;
+  z-index: 99;
+}
+
+.alert {
+  background: var(--color-silver);
+  border-radius: 10px;
+  width: 80%;
+  height: fit-content;
+  box-sizing: border-box;
+  padding: 20px;
+  line-height: 150%;
+  color: var(--color-black);
+  font-weight: 400;
+  font-size: 16px;
+  box-shadow: 0 0 50px 10px rgb(0 0 0 / 20%);
+  z-index: 100;
+}
+
+p {
+  margin: 0;
+}
+</style>

--- a/src/popup/components/Alert.vue
+++ b/src/popup/components/Alert.vue
@@ -1,17 +1,44 @@
 <!-- @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3 -->
 <template>
-  <div class="bg" v-if="show">
-    <div class="alert">
-      <p v-html="title"></p>
-      <a v-on:click="openLink(button_url)" href="#" v-html="button_title"></a>
+  <div class="bg" v-if="showChromeRequiresDevMode || showHostPermissions">
+    <div
+      class="alert alertChromeRequiresDevMode"
+      v-if="showChromeRequiresDevMode"
+    >
+      <p v-html="_('alertChromeRequiresDevModeTitle')"></p>
+      <div
+        v-on:click="onClickButton('chromeDevMode')"
+        class="button"
+        v-html="_('alertChromeRequiresDevModeButton')"
+      ></div>
+    </div>
+    <div class="alert alertHostPermissions" v-if="showHostPermissions">
+      <p v-html="_('alertHostPermissionsRequiredTitle')"></p>
+      <div
+        v-on:click="onClickButton('hostPermissionIntel')"
+        class="button"
+        v-html="_('alertHostPermissionsRequiredButtonIntel')"
+      ></div>
+      <div
+        v-on:click="onClickButton('hostPermissionAllUrls')"
+        class="button"
+        v-html="_('alertHostPermissionsRequiredButtonAllUrls')"
+      ></div>
     </div>
   </div>
 </template>
 
 <script>
 import { mixin } from "./mixins.js";
-import { IS_USERSCRIPTS_API } from "@/userscripts/env";
+import { IS_LEGACY_API, IS_USERSCRIPTS_API } from "@/userscripts/env";
 import browser from "webextension-polyfill";
+
+const intelOrigins = {
+  origins: ["https://intel.ingress.com/*"],
+};
+const allUrlsOrigins = {
+  origins: ["http://*/*", "https://*/*"],
+};
 
 export default {
   name: "Message",
@@ -19,29 +46,67 @@ export default {
   data() {
     return {
       show: false,
-      title: this._("alertChromeRequiresDevModeTitle"),
-      button_title: this._("alertChromeRequiresDevModeButton"),
-      button_url:
-        "https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users",
+      showChromeRequiresDevMode: false,
+      showHostPermissions: false,
     };
   },
-  mounted() {
+  methods: {
+    onClickButton: async function (action) {
+      switch (action) {
+        case "chromeRequiresDevMode":
+          await this.openLink(
+            "https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users"
+          );
+          break;
+        case "hostPermissionIntel":
+          await this.requestPermissions(intelOrigins);
+          break;
+        case "hostPermissionAllUrls":
+          await this.requestPermissions(allUrlsOrigins);
+          break;
+      }
+    },
+    checkHostPermissions: async function () {
+      const testIntelPermissionResult = await browser.permissions.contains(
+        intelOrigins
+      );
+      const testAllUrlsPermissionResult = await browser.permissions.contains(
+        allUrlsOrigins
+      );
+      return testIntelPermissionResult || testAllUrlsPermissionResult;
+    },
+    requestPermissions: async function requestPermissions(permissions) {
+      function onResponse(response) {
+        if (response) {
+          console.log("Permission was granted");
+          window.close();
+        } else {
+          console.log("Permission was refused");
+        }
+      }
+      const response = await browser.permissions.request(permissions);
+      await onResponse(response);
+    },
+  },
+  async mounted() {
     if (IS_USERSCRIPTS_API) {
-      browser.runtime
-        .sendMessage({
-          type: "checkUserScriptsApiAvailable",
-        })
-        .then();
+      await browser.runtime.sendMessage({
+        type: "checkUserScriptsApiAvailable",
+      });
     }
 
     const self = this;
     browser.runtime.onMessage.addListener(async function (request) {
       switch (request.type) {
         case "resolveCheckUserScriptsApiAvailable":
-          self.$data.show = !request.data;
+          self.showChromeRequiresDevMode = !request.data;
           break;
       }
     });
+
+    if (!IS_LEGACY_API && !(await this.checkHostPermissions())) {
+      this.showHostPermissions = true;
+    }
   },
 };
 </script>
@@ -54,6 +119,7 @@ export default {
   width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   background: rgb(0 0 0 / 50%);
   justify-content: center;
   align-items: center;
@@ -71,11 +137,28 @@ export default {
   color: var(--color-black);
   font-weight: 400;
   font-size: 16px;
+  margin: 10px;
   box-shadow: 0 0 50px 10px rgb(0 0 0 / 20%);
   z-index: 100;
 }
 
 p {
   margin: 0;
+}
+
+.button {
+  background: #455a64;
+  color: #fff;
+  border: #37474f;
+  padding: 5px;
+  text-align: center;
+  margin-top: 10px;
+  border-radius: 5px;
+}
+
+.button:hover,
+.button:active,
+.button:focus {
+  background: #546e7a;
 }
 </style>

--- a/src/userscripts/env.js
+++ b/src/userscripts/env.js
@@ -1,0 +1,9 @@
+//@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+
+import browser from "webextension-polyfill";
+
+export const IS_CHROME = !!browser.runtime.OnInstalledReason.CHROME_UPDATE;
+export const MANIFEST = browser.runtime.getManifest();
+
+export const IS_USERSCRIPTS_API = IS_CHROME && MANIFEST.manifest_version === 3;
+export const IS_SCRIPTING_API = !IS_USERSCRIPTS_API;

--- a/src/userscripts/env.js
+++ b/src/userscripts/env.js
@@ -2,9 +2,9 @@
 
 import browser from "webextension-polyfill";
 
-export const IS_CHROME = !!browser.runtime.OnInstalledReason.CHROME_UPDATE;
+export const IS_CHROME = !!browser.runtime.OnInstalledReason?.CHROME_UPDATE;
 export const MANIFEST = browser.runtime.getManifest();
 
 export const IS_USERSCRIPTS_API = IS_CHROME && MANIFEST.manifest_version === 3;
-export const IS_SCRIPTING_API = !IS_USERSCRIPTS_API;
-export const IS_LEGACY_API = MANIFEST.manifest_version === 2;
+export const IS_SCRIPTING_API = !!browser.scripting;
+export const IS_LEGACY_API = !IS_USERSCRIPTS_API && !IS_SCRIPTING_API;

--- a/src/userscripts/env.js
+++ b/src/userscripts/env.js
@@ -7,3 +7,4 @@ export const MANIFEST = browser.runtime.getManifest();
 
 export const IS_USERSCRIPTS_API = IS_CHROME && MANIFEST.manifest_version === 3;
 export const IS_SCRIPTING_API = !IS_USERSCRIPTS_API;
+export const IS_LEGACY_API = MANIFEST.manifest_version === 2;

--- a/src/userscripts/gm-api.js
+++ b/src/userscripts/gm-api.js
@@ -1,5 +1,12 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 export const GM = function () {
+  document.addEventListener("DOMContentLoaded", function () {
+    if (window.location.hostname === "intel.ingress.com") {
+      window.onload = function () {};
+      document.body.onload = function () {};
+    }
+  });
+
   const cache = {};
   const defineProperty = Object.defineProperty;
 
@@ -178,7 +185,7 @@ export const GM = function () {
       cloneInto: makeFunc((obj) => obj),
     };
   };
-  document.addEventListener("bridgeResponse", function (e) {
+  addEventListener("bridgeResponse", function (e) {
     const detail = JSON.parse(base64ToStr(e.detail));
     const uuid = detail.task_uuid;
 

--- a/src/userscripts/utils.js
+++ b/src/userscripts/utils.js
@@ -1,0 +1,10 @@
+//@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+
+import browser from "webextension-polyfill";
+
+export async function isIITCEnabled() {
+  const status = await browser.storage.local
+    .get(["IITC_is_enabled"])
+    .then((data) => data["IITC_is_enabled"]);
+  return status !== false;
+}

--- a/src/userscripts/utils.js
+++ b/src/userscripts/utils.js
@@ -21,16 +21,6 @@ export function is_userscripts_api_available() {
   }
 }
 
-export function is_scripting_api_available() {
-  try {
-    browser.scripting.executeScript().then();
-    return true;
-  } catch {
-    // Not available.
-    return false;
-  }
-}
-
 export const init_userscripts_api = () => {
   if (!is_userscripts_api_available()) return;
   try {

--- a/src/userscripts/utils.js
+++ b/src/userscripts/utils.js
@@ -13,8 +13,7 @@ export async function is_iitc_enabled() {
 export function is_userscripts_api_available() {
   try {
     // Property access which throws if developer mode is not enabled.
-    browser.userScripts;
-    return true;
+    return browser.userScripts !== undefined;
   } catch {
     // Not available.
     return false;

--- a/src/userscripts/utils.js
+++ b/src/userscripts/utils.js
@@ -1,6 +1,7 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
+import { inject_gm_api } from "@/userscripts/wrapper";
 
 export async function is_iitc_enabled() {
   const status = await browser.storage.local
@@ -12,10 +13,22 @@ export async function is_iitc_enabled() {
 export function is_userscripts_api_available() {
   try {
     // Property access which throws if developer mode is not enabled.
-    chrome.userScripts;
+    browser.userScripts;
     return true;
   } catch {
     // Not available.
     return false;
   }
 }
+
+export const init_userscripts_api = () => {
+  if (!is_userscripts_api_available) return;
+  try {
+    browser.userScripts.configureWorld({
+      csp: "script-src 'self' 'unsafe-inline'",
+      messaging: true,
+    });
+    inject_gm_api();
+    // eslint-disable-next-line no-empty
+  } catch {}
+};

--- a/src/userscripts/utils.js
+++ b/src/userscripts/utils.js
@@ -21,8 +21,18 @@ export function is_userscripts_api_available() {
   }
 }
 
+export function is_scripting_api_available() {
+  try {
+    browser.scripting.executeScript().then();
+    return true;
+  } catch {
+    // Not available.
+    return false;
+  }
+}
+
 export const init_userscripts_api = () => {
-  if (!is_userscripts_api_available) return;
+  if (!is_userscripts_api_available()) return;
   try {
     browser.userScripts.configureWorld({
       csp: "script-src 'self' 'unsafe-inline'",

--- a/src/userscripts/utils.js
+++ b/src/userscripts/utils.js
@@ -2,9 +2,20 @@
 
 import browser from "webextension-polyfill";
 
-export async function isIITCEnabled() {
+export async function is_iitc_enabled() {
   const status = await browser.storage.local
     .get(["IITC_is_enabled"])
     .then((data) => data["IITC_is_enabled"]);
   return status !== false;
+}
+
+export function is_userscripts_api_available() {
+  try {
+    // Property access which throws if developer mode is not enabled.
+    chrome.userScripts;
+    return true;
+  } catch {
+    // Not available.
+    return false;
+  }
 }

--- a/src/userscripts/wrapper.js
+++ b/src/userscripts/wrapper.js
@@ -10,7 +10,7 @@ import { strToBase64 } from "@/strToBase64";
 import { getUID } from "lib-iitc-manager";
 import { inject } from "@/content-scripts/utils";
 import { GM } from "@/userscripts/gm-api";
-import { isIITCEnabled } from "@/userscripts/utils";
+import { is_iitc_enabled } from "@/userscripts/utils";
 
 function getPluginHash(uid) {
   return "VMin" + strToBase64(uid);
@@ -19,7 +19,7 @@ function getPluginHash(uid) {
 export async function inject_plugin(plugin, use_gm_api) {
   if (use_gm_api === undefined) use_gm_api = true;
 
-  const iitc_status = await isIITCEnabled();
+  const iitc_status = await is_iitc_enabled();
   if (iitc_status === false) return;
 
   if (IS_USERSCRIPTS_API) {
@@ -73,15 +73,4 @@ export async function gm_api_for_plugin(plugin, tab_id) {
       "plugins/%20" + name + ".user.js"
     )}`,
   ].join("");
-}
-
-export function is_userscripts_api_available() {
-  try {
-    // Property access which throws if developer mode is not enabled.
-    chrome.userScripts;
-    return true;
-  } catch {
-    // Not available.
-    return false;
-  }
 }

--- a/src/userscripts/wrapper.js
+++ b/src/userscripts/wrapper.js
@@ -5,11 +5,19 @@ import { IS_USERSCRIPTS_API } from "@/userscripts/env";
 import { manage_userscripts_api } from "@/background/injector";
 import { strToBase64 } from "@/strToBase64";
 import { getUID } from "lib-iitc-manager";
-import { inject } from "@/content-scripts/utils";
 import { GM } from "@/userscripts/gm-api";
 
 function getPluginHash(uid) {
   return "VMin" + strToBase64(uid);
+}
+
+function inject(code) {
+  const script = document.createElement("script");
+  script.appendChild(document.createTextNode(code));
+  (document.body || document.head || document.documentElement).appendChild(
+    script
+  );
+  script.parentElement.removeChild(script);
 }
 
 export function inject_gm_api() {

--- a/src/userscripts/wrapper.js
+++ b/src/userscripts/wrapper.js
@@ -2,33 +2,14 @@
 
 import browser from "webextension-polyfill";
 import { IS_USERSCRIPTS_API } from "@/userscripts/env";
-import {
-  inject_plugin_via_content_scripts,
-  inject_plugin_via_userscripts_api,
-} from "@/background/injector";
+import { manage_userscripts_api } from "@/background/injector";
 import { strToBase64 } from "@/strToBase64";
 import { getUID } from "lib-iitc-manager";
 import { inject } from "@/content-scripts/utils";
 import { GM } from "@/userscripts/gm-api";
-import { is_iitc_enabled } from "@/userscripts/utils";
 
 function getPluginHash(uid) {
   return "VMin" + strToBase64(uid);
-}
-
-export async function inject_plugin(plugin, use_gm_api) {
-  if (use_gm_api === undefined) use_gm_api = true;
-
-  const iitc_status = await is_iitc_enabled();
-  if (iitc_status === false) return;
-
-  if (IS_USERSCRIPTS_API) {
-    console.log("INJECT LIKE IS CHROME MV3");
-    await inject_plugin_via_userscripts_api(plugin, use_gm_api);
-  } else {
-    console.log("INJECT LIKE OTHER BROWSER");
-    await inject_plugin_via_content_scripts(plugin, use_gm_api);
-  }
 }
 
 export function inject_gm_api() {
@@ -40,7 +21,12 @@ export function inject_gm_api() {
   };
 
   if (IS_USERSCRIPTS_API) {
-    inject_plugin_via_userscripts_api(plugin, false).then();
+    const plugins_event = {
+      event: "add",
+      use_gm_api: false,
+      plugins: [plugin],
+    };
+    manage_userscripts_api(plugins_event).then();
   } else {
     inject(plugin.code);
   }

--- a/src/userscripts/wrapper.js
+++ b/src/userscripts/wrapper.js
@@ -1,0 +1,87 @@
+//@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+
+import browser from "webextension-polyfill";
+import { IS_USERSCRIPTS_API } from "@/userscripts/env";
+import {
+  inject_plugin_via_content_scripts,
+  inject_plugin_via_userscripts_api,
+} from "@/background/injector";
+import { strToBase64 } from "@/strToBase64";
+import { getUID } from "lib-iitc-manager";
+import { inject } from "@/content-scripts/utils";
+import { GM } from "@/userscripts/gm-api";
+import { isIITCEnabled } from "@/userscripts/utils";
+
+function getPluginHash(uid) {
+  return "VMin" + strToBase64(uid);
+}
+
+export async function inject_plugin(plugin, use_gm_api) {
+  if (use_gm_api === undefined) use_gm_api = true;
+
+  const iitc_status = await isIITCEnabled();
+  if (iitc_status === false) return;
+
+  if (IS_USERSCRIPTS_API) {
+    console.log("INJECT LIKE IS CHROME MV3");
+    await inject_plugin_via_userscripts_api(plugin, use_gm_api);
+  } else {
+    console.log("INJECT LIKE OTHER BROWSER");
+    await inject_plugin_via_content_scripts(plugin, use_gm_api);
+  }
+}
+
+export function inject_gm_api() {
+  const plugin = {
+    uid: "gm_api",
+    code: `((${GM.toString()}))()\n//# sourceURL=${browser.runtime.getURL(
+      "js/GM_api.js"
+    )}`,
+  };
+
+  if (IS_USERSCRIPTS_API) {
+    inject_plugin_via_userscripts_api(plugin, false).then();
+  } else {
+    inject(plugin.code);
+  }
+}
+
+export async function gm_api_for_plugin(plugin, tab_id) {
+  const uid = plugin.uid ? plugin.uid : getUID(plugin);
+  let data_key = getPluginHash(uid);
+  const name = encodeURIComponent(plugin.name);
+
+  const meta = { ...plugin };
+  delete meta.code;
+
+  return [
+    "((GM)=>{",
+    // an implementation of GM API v3 based on GM API v4
+    "const GM_info = GM.info; const unsafeWindow = window;",
+    "const exportFunction = GM.exportFunction; const createObjectIn = GM.createObjectIn; const cloneInto = GM.cloneInto;",
+    "const GM_getValue = (key, value) => GM._getValueSync(key, value);",
+    "const GM_setValue = (key, value) => GM._setValueSync(key, value);",
+    "const GM_xmlhttpRequest = (details) => GM.xmlHttpRequest(details);",
+
+    plugin.code,
+    // adding a new line in case the code ends with a line comment
+    plugin.code.endsWith("\n") ? "" : "\n",
+    `})(GM("${data_key}", ${tab_id}, ${JSON.stringify(meta)}))`,
+
+    // Firefox lists .user.js among our own content scripts so a space at start will group them
+    `\n//# sourceURL=${browser.runtime.getURL(
+      "plugins/%20" + name + ".user.js"
+    )}`,
+  ].join("");
+}
+
+export function is_userscripts_api_available() {
+  try {
+    // Property access which throws if developer mode is not enabled.
+    chrome.userScripts;
+    return true;
+  } catch {
+    // Not available.
+    return false;
+  }
+}

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,7 +5,12 @@ const manifest_transformer = (manifest) => {
   if (manifest_version === "2") {
     manifest_v2_transformer(manifest, browser);
   } else if (manifest_version === "3") {
+    if (browser === undefined) {
+      throw Error("BROWSER environment variable is not set");
+    }
     manifest_v3_transformer(manifest, browser);
+  } else {
+    throw Error("MANIFEST_VERSION environment variable is not set");
   }
   manifest.manifest_version = parseInt(manifest_version);
 };
@@ -113,6 +118,14 @@ module.exports = {
       manifestTransformer: (manifest) => {
         manifest_transformer(manifest);
         return manifest;
+      },
+      artifactFilename: ({ name, version, mode }) => {
+        const browser =
+          process.env.MANIFEST_VERSION === "3" ? process.env.BROWSER : "all";
+        if (mode === "production") {
+          return `${name}-v${version}-${browser}-MV${process.env.MANIFEST_VERSION}.zip`;
+        }
+        return `${name}-v${version}-${browser}-MV${process.env.MANIFEST_VERSION}-${mode}.zip`;
       },
     },
   },

--- a/vue.config.js
+++ b/vue.config.js
@@ -51,6 +51,7 @@ const manifest_v3_transformer = (manifest, browser) => {
   if (browser === "chrome") {
     manifest.minimum_chrome_version = "120";
     manifest.permissions.push("userScripts");
+    manifest.permissions.push("alarms");
     manifest.background.service_worker = "js/background.js";
 
     manifest.web_accessible_resources = [

--- a/vue.config.js
+++ b/vue.config.js
@@ -60,6 +60,7 @@ const manifest_v3_transformer = (manifest, browser) => {
       },
     ];
   } else {
+    manifest.permissions.push("webRequestBlocking");
     manifest.permissions.push("scripting");
     manifest.background.page = "background.html";
   }

--- a/vue.config.js
+++ b/vue.config.js
@@ -38,7 +38,25 @@ module.exports = {
         if (process.env.BROWSER === "safari-ios") {
           manifest.background.persistent = false;
         }
+        if (process.env.BROWSER === "firefox") {
+          manifest.permissions.append("webRequestBlocking");
+          manifest.background.page = "background.html";
+        }
         return manifest;
+      },
+    },
+  },
+  chainWebpack: (config) => {
+    config.optimization.delete("splitChunks");
+  },
+  configureWebpack: {
+    devtool: "cheap-module-source-map",
+    optimization: {
+      splitChunks: {
+        cacheGroups: {
+          default: false,
+          vendors: false,
+        },
       },
     },
   },

--- a/vue.config.js
+++ b/vue.config.js
@@ -19,7 +19,6 @@ const manifest_v2_transformer = (manifest, browser) => {
     },
   ];
   manifest.permissions.push("<all_urls>");
-  manifest.permissions.push("scripting");
   manifest.permissions.push("webRequest");
   manifest.permissions.push("webRequestBlocking");
   manifest.background.page = "background.html";

--- a/vue.config.js
+++ b/vue.config.js
@@ -30,12 +30,7 @@ const manifest_v2_transformer = (manifest, browser) => {
 };
 
 const manifest_v3_transformer = (manifest, browser) => {
-  manifest.host_permissions = [
-    "https://intel.ingress.com/*",
-    "https://missions.ingress.com/*",
-    "https://v.enl.one/",
-  ];
-  manifest.optional_host_permissions = ["https://*/*", "http://*/*"];
+  manifest.host_permissions = ["http://*/*", "https://*/*"];
   manifest.content_security_policy = {
     extension_pages:
       "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws://localhost:9090 http://localhost:8000 https://*; img-src 'self' https://iitc.app",
@@ -47,6 +42,8 @@ const manifest_v3_transformer = (manifest, browser) => {
       js: ["js/content-script.js"],
     },
   ];
+  manifest.permissions.push("webRequest");
+  manifest.permissions.push("declarativeNetRequest");
 
   manifest.action = manifest.browser_action;
   delete manifest.browser_action;
@@ -55,10 +52,15 @@ const manifest_v3_transformer = (manifest, browser) => {
     manifest.minimum_chrome_version = "120";
     manifest.permissions.push("userScripts");
     manifest.background.service_worker = "js/background.js";
+
+    manifest.web_accessible_resources = [
+      {
+        resources: ["jsview.html"],
+        matches: ["<all_urls>"],
+      },
+    ];
   } else {
     manifest.permissions.push("scripting");
-    manifest.permissions.push("webRequest");
-    manifest.permissions.push("webRequestBlocking");
     manifest.background.page = "background.html";
   }
 };

--- a/vue.config.js
+++ b/vue.config.js
@@ -63,10 +63,14 @@ const manifest_v3_transformer = (manifest, browser) => {
         matches: ["<all_urls>"],
       },
     ];
-  } else {
+  }
+  if (browser === "firefox" || browser === "safari") {
     manifest.permissions.push("webRequestBlocking");
     manifest.permissions.push("scripting");
     manifest.background.page = "background.html";
+  }
+  if (browser === "safari") {
+    delete manifest.content_security_policy;
   }
 };
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,68 @@
+const manifest_transformer = (manifest) => {
+  const browser = process.env.BROWSER;
+  const manifest_version = process.env.MANIFEST_VERSION;
+
+  if (manifest_version === "2") {
+    manifest_v2_transformer(manifest, browser);
+  } else if (manifest_version === "3") {
+    manifest_v3_transformer(manifest, browser);
+  }
+  manifest.manifest_version = parseInt(manifest_version);
+};
+
+const manifest_v2_transformer = (manifest, browser) => {
+  manifest.content_scripts = [
+    {
+      matches: ["<all_urls>"],
+      run_at: "document_start",
+      js: ["js/content-script.js"],
+    },
+  ];
+  manifest.permissions.push("<all_urls>");
+  manifest.permissions.push("scripting");
+  manifest.permissions.push("webRequest");
+  manifest.permissions.push("webRequestBlocking");
+  manifest.background.page = "background.html";
+
+  if (browser === "safari-ios") {
+    manifest.background.persistent = false;
+  }
+};
+
+const manifest_v3_transformer = (manifest, browser) => {
+  manifest.host_permissions = [
+    "https://intel.ingress.com/*",
+    "https://missions.ingress.com/*",
+    "https://v.enl.one/",
+  ];
+  manifest.optional_host_permissions = ["https://*/*", "http://*/*"];
+  manifest.content_security_policy = {
+    extension_pages:
+      "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws://localhost:9090 http://localhost:8000 https://*; img-src 'self' https://iitc.app",
+  };
+  manifest.content_scripts = [
+    {
+      matches: ["<all_urls>"],
+      run_at: "document_start",
+      js: ["js/content-script.js"],
+    },
+  ];
+
+  manifest.action = manifest.browser_action;
+  delete manifest.browser_action;
+
+  if (browser === "chrome") {
+    manifest.minimum_chrome_version = "120";
+    manifest.permissions.push("userScripts");
+    manifest.background.service_worker = "js/background.js";
+  } else {
+    manifest.permissions.push("scripting");
+    manifest.permissions.push("webRequest");
+    manifest.permissions.push("webRequestBlocking");
+    manifest.background.page = "background.html";
+  }
+};
+
 module.exports = {
   filenameHashing: false,
   productionSourceMap: false,
@@ -35,13 +100,7 @@ module.exports = {
         },
       },
       manifestTransformer: (manifest) => {
-        if (process.env.BROWSER === "safari-ios") {
-          manifest.background.persistent = false;
-        }
-        if (process.env.BROWSER === "firefox") {
-          manifest.permissions.append("webRequestBlocking");
-          manifest.background.page = "background.html";
-        }
+        manifest_transformer(manifest);
         return manifest;
       },
     },

--- a/vue.config.js
+++ b/vue.config.js
@@ -29,7 +29,11 @@ const manifest_v2_transformer = (manifest, browser) => {
 };
 
 const manifest_v3_transformer = (manifest, browser) => {
-  manifest.host_permissions = ["http://*/*", "https://*/*"];
+  manifest.host_permissions = [
+    "https://intel.ingress.com/*",
+    "http://*/*",
+    "https://*/*",
+  ];
   manifest.content_security_policy = {
     extension_pages:
       "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws://localhost:9090 http://localhost:8000 https://*; img-src 'self' https://iitc.app",
@@ -42,7 +46,6 @@ const manifest_v3_transformer = (manifest, browser) => {
     },
   ];
   manifest.permissions.push("webRequest");
-  manifest.permissions.push("declarativeNetRequest");
 
   manifest.action = manifest.browser_action;
   delete manifest.browser_action;
@@ -51,6 +54,7 @@ const manifest_v3_transformer = (manifest, browser) => {
     manifest.minimum_chrome_version = "120";
     manifest.permissions.push("userScripts");
     manifest.permissions.push("alarms");
+    manifest.permissions.push("declarativeNetRequest");
     manifest.background.service_worker = "js/background.js";
 
     manifest.web_accessible_resources = [


### PR DESCRIPTION
- [x] Add the ability to work with manifest v3
- [x] Ensure GM API works with MV3
- [x] Track the opening of .user.js files on websites and suggest installation in MV3
- [x] In the service worker, [create a timer](https://developer.chrome.com/docs/extensions/reference/api/alarms) to check for updates.
- [x] Unregister disabled plugins
- [x] Update GitHub Actions to build artifacts for different browsers and Manifest versions

Test with Manifest V2 and browsers other than Chrome
- [x] Firefox MV2
- [x] Chrome MV2
- [x] Safari MV2 (partially)
- [x] Firefox MV3
- [x] Chrome MV3
- [x] Safari MV3 (partially)