### PR TITLE
Fix version number for Beta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,14 @@ jobs:
           - build_script: build_mv3_chrome
           - build_script: build_mv3_safari
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -35,9 +38,11 @@ jobs:
       - name: Linter
         run: npm run lint
 
-      - name: Set BETA environment variable
+      - name: Set BETA environment variables
         if: startsWith(github.ref, 'refs/tags/v') != true
-        run: echo "BETA=true" >> $GITHUB_ENV
+        run: |
+          echo "BETA=true" >> $GITHUB_ENV
+          echo "GIT_REV_COUNT=`git rev-list --all --count`" >> $GITHUB_ENV
 
       - name: Build
         run: npm run ${{ matrix.build_script }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iitc-button",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iitc-button",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "GPLv3",
       "dependencies": {
         "@highlightjs/vue-plugin": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iitc-button",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "repository": "https://github.com/IITC-CE/IITC-Button.git",
   "license": "GPLv3",
   "private": true,

--- a/vue.config.js
+++ b/vue.config.js
@@ -12,14 +12,8 @@ const manifest_transformer = (manifest) => {
     manifest.icons["48"] = "assets/icons/48/icon-beta.png";
     manifest.icons["128"] = "assets/icons/128/icon-beta.png";
 
-    let currentDate = new Date();
-    let year = String(currentDate.getFullYear()).slice(-2);
-    let month = String(currentDate.getMonth() + 1).padStart(2, "0");
-    let day = String(currentDate.getDate()).padStart(2, "0");
-    let hours = String(currentDate.getHours()).padStart(2, "0");
-
-    let formattedDate = `${year}${month}${day}${hours}`;
-    manifest.version = `${manifest.version}.${formattedDate}`;
+    const git_rev_count = parseInt(process.env.GIT_REV_COUNT) % 65535;
+    manifest.version = `${manifest.version}.${git_rev_count}`;
   }
 
   if (manifest_version === "2") {


### PR DESCRIPTION
One to four dot-separated integers identifying the version of this extension. A couple of rules apply to the integers:

    The integers must be between 0 and 65535, inclusive.
    Non-zero integers can't start with 0. For example, 032 is invalid because it begins with a zero.
    They must not be all zero. For example, 0 and 0.0.0.0 are invalid while 0.1.0.0 is valid.

https://developer.chrome.com/docs/extensions/reference/manifest/version