### PR TITLE
Update userScripts permission alert for Chrome 138+

### DIFF
--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -230,7 +230,7 @@
     "saveToJson": {
         "message": "Als json speichern"
     },
-    "alertChromeRequiresDevModeTitle": {
+    "alertChromeRequiresUserScriptsTitle": {
         "message": "Für unsere Erweiterung muss der Entwicklermodus aktiviert sein, um UserScripts zu verwalten, da Manifest&nbsp;V3 Einschränkungen in Chrome hat. Es ist einfach zu aktivieren!"
     },
     "jsViewDetailsNoDomains": {
@@ -245,7 +245,7 @@
             }
         }
     },
-    "alertChromeRequiresDevModeButton": {
+    "alertChromeRequiresUserScriptsButton": {
         "message": "Bitte folge dieser Anleitung"
     },
     "alertHostPermissionsRequiredTitle": {

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -272,10 +272,10 @@
     "saveToJson": {
         "message": "Save to json"
     },
-    "alertChromeRequiresDevModeTitle": {
-        "message": "Our extension requires Developer&nbsp;Mode to be enabled to manage UserScripts, due to Manifest&nbsp;V3 limitations in Chrome. It's easy to enable!"
+    "alertChromeRequiresUserScriptsTitle": {
+        "message": "Enable User Scripts for this extension due to Manifest&nbsp;V3 limitations in Chrome"
     },
-    "alertChromeRequiresDevModeButton": {
+    "alertChromeRequiresUserScriptsButton": {
         "message": "Please follow this guide"
     },
     "alertHostPermissionsRequiredTitle": {

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -197,7 +197,7 @@
     "jsViewDetailsHideDetails": {
         "message": "Ukryj szczegóły"
     },
-    "alertChromeRequiresDevModeButton": {
+    "alertChromeRequiresUserScriptsButton": {
         "message": "Postępuj zgodnie z tym przewodnikiem"
     },
     "alertHostPermissionsRequiredTitle": {
@@ -227,7 +227,7 @@
     "warningAboutLocalStoragePart1": {
         "message": "Należy pamiętać, że localStorage zawiera wszystkie dane dostępne dla przycisku IITC. Przykładowo, załączenie listy Twoich wtyczek i ich kodu źródłowego może obejmować ustawienia niektórych wtyczek (w zależności od ich implementacji)."
     },
-    "alertChromeRequiresDevModeTitle": {
+    "alertChromeRequiresUserScriptsTitle": {
         "message": "Nasze rozszerzenie wymaga włączenia trybu programisty w celu zarządzania skryptami użytkownika ze względu na ograniczenia Manifest&nbsp;V3 w przeglądarce Chrome. Włączenie jest łatwe!"
     },
     "other": {

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -263,7 +263,7 @@
     "every5seconds": {
         "message": "A cada 5 segundos"
     },
-    "alertChromeRequiresDevModeButton": {
+    "alertChromeRequiresUserScriptsButton": {
         "message": "Por favor, siga este guia"
     },
     "alertHostPermissionsRequiredButtonIntel": {
@@ -272,7 +272,7 @@
     "alertHostPermissionsRequiredButtonAllUrls": {
         "message": "Todos os URLs para garantir suporte total"
     },
-    "alertChromeRequiresDevModeTitle": {
+    "alertChromeRequiresUserScriptsTitle": {
         "message": "Nossa extensão requer que o Modo Desenvolvedor esteja habilitado para gerenciar UserScripts, devido às limitações do Manifest V3 no Chrome. É fácil ativar!"
     },
     "alertHostPermissionsRequiredTitle": {

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -265,7 +265,7 @@
     "alertHostPermissionsRequiredButtonIntel": {
         "message": "只用于Ingress Intel"
     },
-    "alertChromeRequiresDevModeButton": {
+    "alertChromeRequiresUserScriptsButton": {
         "message": "请遵循本指南"
     },
     "alertHostPermissionsRequiredTitle": {
@@ -274,7 +274,7 @@
     "alertHostPermissionsRequiredButtonAllUrls": {
         "message": "以确保所有 URL能得到完整的支持"
     },
-    "alertChromeRequiresDevModeTitle": {
+    "alertChromeRequiresUserScriptsTitle": {
         "message": "由于Chrome使用了Manifest&nbsp;V3，因此本插件需要开启“开发者模式”来管理用户脚本，请在设置--扩展程序，开启“开发者模式”按钮！"
     },
     "importFromJson": {

--- a/src/popup/components/Alert.vue
+++ b/src/popup/components/Alert.vue
@@ -1,15 +1,15 @@
 <!-- @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3 -->
 <template>
-  <div class="bg" v-if="showChromeRequiresDevMode || showHostPermissions">
+  <div class="bg" v-if="showChromeRequiresUserScripts || showHostPermissions">
     <div
-      class="alert alertChromeRequiresDevMode"
-      v-if="showChromeRequiresDevMode"
+      class="alert alertChromeRequiresUserScripts"
+      v-if="showChromeRequiresUserScripts"
     >
-      <p v-html="_('alertChromeRequiresDevModeTitle')"></p>
+      <p v-html="_('alertChromeRequiresUserScriptsTitle')"></p>
       <div
-        v-on:click="onClickButton('chromeDevMode')"
+        v-on:click="onClickButton('chromeUserScripts')"
         class="button"
-        v-html="_('alertChromeRequiresDevModeButton')"
+        v-html="_('alertChromeRequiresUserScriptsButton')"
       ></div>
     </div>
     <div class="alert alertHostPermissions" v-if="showHostPermissions">
@@ -46,17 +46,15 @@ export default {
   data() {
     return {
       show: false,
-      showChromeRequiresDevMode: false,
+      showChromeRequiresUserScripts: false,
       showHostPermissions: false,
     };
   },
   methods: {
     onClickButton: async function (action) {
       switch (action) {
-        case "chromeDevMode":
-          await this.openLink(
-            "https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users"
-          );
+        case "chromeUserScripts":
+          await this.openLink("https://www.tampermonkey.net/faq.php#Q209");
           break;
         case "hostPermissionIntel":
           await this.requestPermissions(intelOrigins);
@@ -90,7 +88,7 @@ export default {
     browser.runtime.onMessage.addListener(async function (request) {
       switch (request.type) {
         case "resolveCheckUserScriptsApiAvailable":
-          self.showChromeRequiresDevMode = !request.data;
+          self.showChromeRequiresUserScripts = !request.data;
           break;
       }
     });

--- a/src/popup/components/Alert.vue
+++ b/src/popup/components/Alert.vue
@@ -86,12 +86,6 @@ export default {
     },
   },
   async mounted() {
-    if (IS_USERSCRIPTS_API) {
-      await browser.runtime.sendMessage({
-        type: "checkUserScriptsApiAvailable",
-      });
-    }
-
     const self = this;
     browser.runtime.onMessage.addListener(async function (request) {
       switch (request.type) {
@@ -100,6 +94,12 @@ export default {
           break;
       }
     });
+
+    if (IS_USERSCRIPTS_API) {
+      await browser.runtime.sendMessage({
+        type: "checkUserScriptsApiAvailable",
+      });
+    }
 
     if (!(await this.checkHostPermissions())) {
       this.showHostPermissions = true;


### PR DESCRIPTION
Replace developer mode terminology with generic User Scripts language to support both legacy Chrome versions requiring developer mode and Chrome 138+ requiring User Scripts toggle.

Fix race condition in userScripts API availability check