### PR TITLE
release 3.2.3: fix: save null instead of {} when removing IITC core override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "core-js": "^3.8.3",
         "highlight.js": "^10.7.3",
         "jszip": "^3.10.1",
-        "lib-iitc-manager": "^1.13.3",
+        "lib-iitc-manager": "^1.13.5",
         "scored-fuzzysearch": "^1.0.5",
         "vue": "^2.6.14"
       },
@@ -10236,9 +10236,9 @@
       }
     },
     "node_modules/lib-iitc-manager": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-1.13.3.tgz",
-      "integrity": "sha512-l7tSYMYiKgV5VEh1cBA1tQaHLgBlHcUB8xbvxl1Dfs27kIGYRSU1LLqeQMuoK5MbOqATW1k0/WQBly4aofFzww==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-1.13.5.tgz",
+      "integrity": "sha512-0SHifjcXRb15VyiRxz8mRC8s9xv6HJdsYTPWkVn4NtYx+I/QDrIjVP+FPtwK1bvtXHmLNJAUzSH+OVXNeDVNqA==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iitc-button",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iitc-button",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPLv3",
       "dependencies": {
         "@highlightjs/vue-plugin": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iitc-button",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "repository": "https://github.com/IITC-CE/IITC-Button.git",
   "license": "GPLv3",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "core-js": "^3.8.3",
     "highlight.js": "^10.7.3",
     "jszip": "^3.10.1",
-    "lib-iitc-manager": "^1.13.3",
+    "lib-iitc-manager": "^1.13.5",
     "scored-fuzzysearch": "^1.0.5",
     "vue": "^2.6.14"
   },


### PR DESCRIPTION
[update lib-iitc-manager:](https://github.com/IITC-CE/lib-iitc-manager/commit/3ab0d3535cdf7d077427e4ff78e203d5f99704e5)

**fix: save null instead of {} when removing IITC core override**

{} caused isSet() to return true, so plugin_event fired with an empty plugin object, leaving the old user script active in Chrome.

fix https://github.com/IITC-CE/IITC-Button/issues/184