### PR TITLE
chore: migrate to lib-iitc-manager v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "core-js": "^3.8.3",
         "highlight.js": "^10.7.3",
         "jszip": "^3.10.1",
-        "lib-iitc-manager": "^1.13.7",
+        "lib-iitc-manager": "^2.0.1",
         "scored-fuzzysearch": "^1.0.5",
         "vue": "^2.6.14"
       },
@@ -10236,9 +10236,9 @@
       }
     },
     "node_modules/lib-iitc-manager": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-1.13.7.tgz",
-      "integrity": "sha512-n2/07J1MiVw4aoc+DY2q07C49XSnf30j5nEsJFZal39TB/HOSvqGv8LU15ty+xx3gJROfCT6WHxjyobR+fT+iQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-2.0.1.tgz",
+      "integrity": "sha512-iynZ2xgegyy4SWD50dvIRTAFmGeB871MZW91ZpxiRqUrgFweWkbnJbP8saSUfVQsiaJ6HkxMoQCnsBXqNuwr8A==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "core-js": "^3.8.3",
     "highlight.js": "^10.7.3",
     "jszip": "^3.10.1",
-    "lib-iitc-manager": "^1.13.7",
+    "lib-iitc-manager": "^2.0.1",
     "scored-fuzzysearch": "^1.0.5",
     "vue": "^2.6.14"
   },

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -174,6 +174,8 @@ browser.runtime.onMessage.addListener(async (request, sender) => {
       return manager.channel;
     case "getUpdateCheckInterval":
       return await manager.getUpdateCheckInterval(request.channel);
+    case "getNetworkHost":
+      return manager.networkHost;
     case "setCustomChannelUrl":
       await manager.setCustomChannelUrl(request.value);
       break;

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -44,9 +44,9 @@ const manager = new Manager({
       .then()
       .catch(() => {}); // If popup is closed, message goes nowhere and an error occurs. Ignore.
   },
-  onPluginsViewChanged: ({ plugins, categories }) => {
+  onPluginsViewChanged: ({ plugins, categories, core }) => {
     browser.runtime
-      .sendMessage({ type: "pluginsViewChanged", plugins, categories })
+      .sendMessage({ type: "pluginsViewChanged", plugins, categories, core })
       .then()
       .catch(() => {});
   },

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -170,6 +170,10 @@ browser.runtime.onMessage.addListener(async (request, sender) => {
         .then()
         .catch(() => {}); // If tab is closed, message goes nowhere and an error occurs. Ignore.
       break;
+    case "getChannel":
+      return manager.channel;
+    case "getUpdateCheckInterval":
+      return await manager.getUpdateCheckInterval(request.channel);
     case "setCustomChannelUrl":
       await manager.setCustomChannelUrl(request.value);
       break;
@@ -224,17 +228,8 @@ async function createCheckUpdateAlarm(need_to_update = false) {
     }
   }
 
-  const storage_intervals = await browser.storage.local.get([
-    "channel",
-    "release_update_check_interval",
-    "beta_update_check_interval",
-    "custom_update_check_interval",
-    "external_update_check_interval",
-  ]);
-  const channel_interval_key = `${storage_intervals["channel"]}_update_check_interval`;
-  const channel_interval = storage_intervals[channel_interval_key] || 604800;
-  const external_interval =
-    storage_intervals["external_update_check_interval"] || 604800;
+  const channel_interval = await manager.getUpdateCheckInterval();
+  const external_interval = await manager.getUpdateCheckInterval("external");
 
   let interval_seconds = Math.min(channel_interval, external_interval);
   if (interval_seconds < 30) {
@@ -265,4 +260,3 @@ self.addEventListener("activate", () => {
 });
 
 createCheckUpdateAlarm().then();
-

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -44,6 +44,12 @@ const manager = new Manager({
       .then()
       .catch(() => {}); // If popup is closed, message goes nowhere and an error occurs. Ignore.
   },
+  plugins_view_changed: ({ plugins, categories }) => {
+    browser.runtime
+      .sendMessage({ type: "pluginsViewChanged", plugins, categories })
+      .then()
+      .catch(() => {});
+  },
   inject_plugin: async (plugin) => {
     if (IS_USERSCRIPTS_API) return;
 
@@ -99,6 +105,8 @@ browser.runtime.onMessage.addListener(async (request, sender) => {
     case "XHRFallbackRequest":
       await xmlHttpRequestFallbackHandler(request.value, sender);
       break;
+    case "getPluginsView":
+      return await manager.getPluginsView();
     case "managePlugin":
       await manager.managePlugin(request.uid, request.action);
       break;

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,5 +1,5 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
-import { Manager } from "lib-iitc-manager";
+import { Manager, GM_API_UID } from "lib-iitc-manager";
 import browser from "webextension-polyfill";
 import {
   IS_LEGACY_API,
@@ -192,7 +192,7 @@ async function initUserscriptsApi() {
   } catch {}
 
   const is_gm_api_plugin_exist = scripts.some(
-    (script) => script.id === "gm_api"
+    (script) => script.id === GM_API_UID
   );
   if (is_gm_api_plugin_exist) return;
 

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -35,7 +35,7 @@ const manager = new Manager({
       .then()
       .catch(() => {}); // If popup is closed, message goes nowhere and an error occurs. Ignore.
   },
-  progressbar: (is_show) => {
+  onProgress: (is_show) => {
     browser.runtime
       .sendMessage({
         type: "showProgressbar",
@@ -44,13 +44,13 @@ const manager = new Manager({
       .then()
       .catch(() => {}); // If popup is closed, message goes nowhere and an error occurs. Ignore.
   },
-  plugins_view_changed: ({ plugins, categories }) => {
+  onPluginsViewChanged: ({ plugins, categories }) => {
     browser.runtime
       .sendMessage({ type: "pluginsViewChanged", plugins, categories })
       .then()
       .catch(() => {});
   },
-  inject_plugin: async (plugin) => {
+  injectPlugin: async (plugin) => {
     if (IS_USERSCRIPTS_API) return;
 
     const iitc_status = await is_iitc_enabled();
@@ -58,12 +58,12 @@ const manager = new Manager({
 
     await inject_plugin_via_content_scripts(plugin);
   },
-  plugin_event: async (data) => {
+  onPluginEvent: async (data) => {
     if (IS_SCRIPTING_API) return;
     await manage_userscripts_api(data);
   },
-  gm_api: {
-    bridge_adapter_code: `
+  gmApi: {
+    bridgeAdapterCode: `
       window.__iitc_gm_bridge__ = {
         send(data) {
           document.dispatchEvent(new CustomEvent('bridgeRequest', { detail: data }));
@@ -74,8 +74,8 @@ const manager = new Manager({
       };
     `,
   },
-  source_url_prefix: browser.runtime.getURL("/"),
-  is_daemon: true,
+  sourceUrlPrefix: browser.runtime.getURL("/"),
+  isDaemon: true,
 });
 
 manager.run().then();
@@ -265,3 +265,4 @@ self.addEventListener("activate", () => {
 });
 
 createCheckUpdateAlarm().then();
+

--- a/src/background/injector.js
+++ b/src/background/injector.js
@@ -54,6 +54,7 @@ export async function manage_userscripts_api(plugins_event) {
       return;
     } catch (e) {
       console.log("an error occurred while unregistering the plugin", e);
+      return;
     }
   }
 

--- a/src/background/injector.js
+++ b/src/background/injector.js
@@ -1,6 +1,7 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
+import { GM_API_UID } from "lib-iitc-manager";
 import { getNiaTabsToInject, getPluginMatches } from "@/background/utils";
 import { is_userscripts_api_available } from "@/userscripts/utils";
 import { IS_LEGACY_API } from "@/userscripts/env";
@@ -64,7 +65,7 @@ export async function manage_userscripts_api(plugins_event) {
       id: plugin.uid,
       matches: getPluginMatches(plugin),
       js: [{ code: plugin.code }],
-      runAt: plugin.uid === "gm_api" ? "document_start" : "document_end",
+      runAt: plugin.uid === GM_API_UID ? "document_start" : "document_end",
       world: "MAIN",
     });
   }

--- a/src/background/injector.js
+++ b/src/background/injector.js
@@ -2,7 +2,7 @@
 
 import browser from "webextension-polyfill";
 import { GM_API_UID } from "lib-iitc-manager";
-import { getNiaTabsToInject, getPluginMatches } from "@/background/utils";
+import { getNiaTabsToInject } from "@/background/utils";
 import { is_userscripts_api_available } from "@/userscripts/utils";
 import { IS_LEGACY_API } from "@/userscripts/env";
 
@@ -63,7 +63,8 @@ export async function manage_userscripts_api(plugins_event) {
   for (let plugin of Object.values(plugins)) {
     plugins_obj.push({
       id: plugin.uid,
-      matches: getPluginMatches(plugin),
+      matches: plugin.match ||
+        plugin.include || ["https://intel.ingress.com/*"],
       js: [{ code: plugin.code }],
       runAt: plugin.uid === GM_API_UID ? "document_start" : "document_end",
       world: "MAIN",

--- a/src/background/requests.js
+++ b/src/background/requests.js
@@ -2,7 +2,7 @@
 
 import browser from "webextension-polyfill";
 import { IS_USERSCRIPTS_API } from "@/userscripts/env";
-import { parseMeta, fetchResource, getUniqId } from "lib-iitc-manager";
+import { parseMeta, fetchResource, getUniqueId } from "lib-iitc-manager";
 
 const IS_CHROME = !!global.chrome.app;
 const whitelist = [
@@ -205,7 +205,7 @@ async function maybeInstallUserJs(tabId, url) {
  */
 async function confirmInstall(url, code) {
   const cache = {};
-  const uniqId = getUniqId("tmp");
+  const uniqId = getUniqueId("tmp");
   cache[uniqId] = { url: url, code: code };
   await browser.storage.local.set(cache);
 

--- a/src/background/utils.js
+++ b/src/background/utils.js
@@ -3,10 +3,6 @@
 import browser from "webextension-polyfill";
 import { checkMatching } from "lib-iitc-manager";
 
-const is_ingress_tab = (url) => {
-  return /https:\/\/(intel|missions).ingress.com\/*/.test(url);
-};
-
 // Fetch all completly loaded tabs
 export async function getTabsToInject() {
   let allTabs = await browser.tabs.query({ status: "complete" });
@@ -18,9 +14,5 @@ export async function getTabsToInject() {
 // Filter all completly loaded Ingress Intel tabs
 export async function getNiaTabsToInject(plugin) {
   const tabs = await getTabsToInject();
-  return Object.values(tabs).filter(
-    (tab) =>
-      (is_ingress_tab(tab.url) && checkMatching(plugin, "<all_ingress>")) ||
-      checkMatching(plugin, tab.url)
-  );
+  return Object.values(tabs).filter((tab) => checkMatching(plugin, tab.url));
 }

--- a/src/background/utils.js
+++ b/src/background/utils.js
@@ -24,17 +24,3 @@ export async function getNiaTabsToInject(plugin) {
       checkMatching(plugin, tab.url)
   );
 }
-
-export function getPluginMatches(plugin) {
-  let matches = [];
-  if (checkMatching(plugin, "<all_ingress>")) {
-    matches.push("https://intel.ingress.com/*");
-    matches.push("https://missions.ingress.com/*");
-  }
-  if (plugin.match) {
-    matches = matches.concat(plugin.match);
-  } else if (plugin.include) {
-    matches = matches.concat(plugin.include);
-  }
-  return matches;
-}

--- a/src/background/utils.js
+++ b/src/background/utils.js
@@ -1,7 +1,7 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import browser from "webextension-polyfill";
-import { check_matching } from "lib-iitc-manager";
+import { checkMatching } from "lib-iitc-manager";
 
 const is_ingress_tab = (url) => {
   return /https:\/\/(intel|missions).ingress.com\/*/.test(url);
@@ -20,14 +20,14 @@ export async function getNiaTabsToInject(plugin) {
   const tabs = await getTabsToInject();
   return Object.values(tabs).filter(
     (tab) =>
-      (is_ingress_tab(tab.url) && check_matching(plugin, "<all_ingress>")) ||
-      check_matching(plugin, tab.url)
+      (is_ingress_tab(tab.url) && checkMatching(plugin, "<all_ingress>")) ||
+      checkMatching(plugin, tab.url)
   );
 }
 
 export function getPluginMatches(plugin) {
   let matches = [];
-  if (check_matching(plugin, "<all_ingress>")) {
+  if (checkMatching(plugin, "<all_ingress>")) {
     matches.push("https://intel.ingress.com/*");
     matches.push("https://missions.ingress.com/*");
   }

--- a/src/jsview/App.vue
+++ b/src/jsview/App.vue
@@ -11,7 +11,7 @@ import browser from "webextension-polyfill";
 import Code from "./Code";
 import { _ } from "@/i18n";
 import Header from "./Header";
-import { ajaxGet } from "lib-iitc-manager";
+import { fetchData } from "lib-iitc-manager";
 import { parseMeta } from "lib-iitc-manager";
 
 export default {
@@ -54,9 +54,8 @@ export default {
       tabId = last_userscript_request["tabId"];
       url = last_userscript_request["url"];
 
-      try {
-        code = await ajaxGet(url);
-      } catch {
+      code = await fetchData(url);
+      if (!code) {
         return await this.bypass(tabId, url);
       }
     }

--- a/src/jsview/Header.vue
+++ b/src/jsview/Header.vue
@@ -62,7 +62,7 @@
 <script>
 import browser from "webextension-polyfill";
 import { _ } from "@/i18n";
-import { getUID, humanize_match } from "lib-iitc-manager";
+import { getUID, humanizeMatch } from "lib-iitc-manager";
 import { uuidv4 } from "@/uuid";
 const iitc_core_uid =
   "IITC: Ingress intel map total conversion+https://github.com/IITC-CE/ingress-intel-total-conversion";
@@ -137,7 +137,7 @@ export default {
   },
   watch: {
     meta: function () {
-      this.domains = humanize_match(this.meta);
+      this.domains = humanizeMatch(this.meta);
     },
     code: async function () {
       this.show_header = true;

--- a/src/jsview/Header.vue
+++ b/src/jsview/Header.vue
@@ -62,10 +62,8 @@
 <script>
 import browser from "webextension-polyfill";
 import { _ } from "@/i18n";
-import { getUID, humanizeMatch } from "lib-iitc-manager";
+import { getUID, humanizeMatch, IITC_CORE_UID } from "lib-iitc-manager";
 import { uuidv4 } from "@/uuid";
-const iitc_core_uid =
-  "IITC: Ingress intel map total conversion+https://github.com/IITC-CE/ingress-intel-total-conversion";
 
 export default {
   name: "Header",
@@ -94,7 +92,7 @@ export default {
     },
     checkIfInstalled: async function () {
       const uid = getUID(this.meta);
-      if (uid === iitc_core_uid) {
+      if (uid === IITC_CORE_UID) {
         this.button_name = _("reinstall");
       }
       await browser.runtime.sendMessage({
@@ -115,7 +113,7 @@ export default {
             if (request.id !== self.page_uuid) return;
             Object.entries(request.scripts).map(([, script]) => {
               let message = "";
-              if (script["uid"] === iitc_core_uid) {
+              if (script["uid"] === IITC_CORE_UID) {
                 message = _("addedCustomIITCCore", [script["name"]]) + "\n";
               } else {
                 message =

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -50,7 +50,6 @@ export default {
   },
   async mounted() {
     await data.init(this);
-    await data.onChangedListener(this);
     await data.onMessageListener(this);
     await browser.runtime.sendMessage({ type: "popupWasOpened" });
   },

--- a/src/popup/components/InputCustomServer.vue
+++ b/src/popup/components/InputCustomServer.vue
@@ -109,12 +109,11 @@ export default {
     },
   },
   async mounted() {
-    const network_host = await browser.storage.local
-      .get(["network_host"])
-      .then(({ network_host }) => network_host);
-
-    if (network_host && network_host.custom) {
-      this.host = network_host.custom;
+    const networkHost = await browser.runtime.sendMessage({
+      type: "getNetworkHost",
+    });
+    if (networkHost?.custom) {
+      this.host = networkHost.custom;
     }
     await this.setInputStatus(this.host);
   },

--- a/src/popup/components/InputCustomServer.vue
+++ b/src/popup/components/InputCustomServer.vue
@@ -38,24 +38,8 @@
 
 <script>
 import browser from "webextension-polyfill";
+import { validateCustomChannelUrl } from "lib-iitc-manager";
 import { mixin } from "./mixins.js";
-
-const checkStatusCustomServer = (host) =>
-  new Promise((resolve) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open("GET", `${host}/meta.json?${Date.now()}`, true);
-    xhr.timeout = 1000;
-    xhr.onreadystatechange = function () {
-      if (xhr.readyState === 4) {
-        if (xhr.status === 200) {
-          resolve(true);
-        } else {
-          resolve(false);
-        }
-      }
-    };
-    xhr.send(null);
-  });
 
 export default {
   name: "InputCustomServer",
@@ -72,12 +56,7 @@ export default {
   methods: {
     setInputStatus: async function (host) {
       this.iconName = "error";
-      let status;
-      try {
-        status = await checkStatusCustomServer(host);
-      } catch {
-        status = false;
-      }
+      const status = await validateCustomChannelUrl(host);
       if (status) {
         this.iconName = "check";
       }
@@ -86,14 +65,12 @@ export default {
     changeCustomServer: async function () {
       let connected = await this.setInputStatus(this.host);
 
-      const http_host = "http://" + this.host;
-      if (
-        !connected &&
-        !this.host.startsWith("http") &&
-        (await this.setInputStatus(http_host))
-      ) {
-        connected = await this.setInputStatus(http_host);
-        this.host = http_host;
+      if (!connected && !this.host.startsWith("http")) {
+        const http_host = "http://" + this.host;
+        if (await this.setInputStatus(http_host)) {
+          connected = true;
+          this.host = http_host;
+        }
       }
 
       if (connected) {

--- a/src/popup/components/SectionOptions.vue
+++ b/src/popup/components/SectionOptions.vue
@@ -122,9 +122,9 @@ export default {
     },
   },
   async mounted() {
-    const data = await browser.storage.local.get("channel");
-    if (data.channel) {
-      this.channel = data.channel;
+    const channel = await browser.runtime.sendMessage({ type: "getChannel" });
+    if (channel) {
+      this.channel = channel;
     }
   },
   components: { Hr, Header, UpdateCheckIntervalSelector, InputCustomServer },

--- a/src/popup/components/UpdateCheckIntervalSelector.vue
+++ b/src/popup/components/UpdateCheckIntervalSelector.vue
@@ -52,11 +52,12 @@ export default {
     },
   },
   async mounted() {
-    const key = this.channel + "_update_check_interval";
-    const data = await browser.storage.local.get(key);
-
-    if (data[key]) {
-      this.interval = parseInt(data[key]);
+    const interval = await browser.runtime.sendMessage({
+      type: "getUpdateCheckInterval",
+      channel: this.channel,
+    });
+    if (interval) {
+      this.interval = interval;
     }
   },
 };

--- a/src/popup/data.js
+++ b/src/popup/data.js
@@ -4,26 +4,17 @@ import browser from "webextension-polyfill";
 
 export async function init(self) {
   const appData = self.$data;
-  const [data, view] = await Promise.all([
-    browser.storage.local.get([
-      "channel",
-      "release_iitc_core",
-      "beta_iitc_core",
-      "custom_iitc_core",
-      "iitc_core_user",
-    ]),
-    browser.runtime.sendMessage({ type: "getPluginsView" }),
-  ]);
-  const channel = data.channel ? data.channel : "release";
-  // initialize plugins and categories from library
+  const view = await browser.runtime.sendMessage({ type: "getPluginsView" });
   setPluginsView(appData, view || {});
-  // initialize iitc core
-  setIitcCore(appData, data[channel + "_iitc_core"], data["iitc_core_user"]);
 }
 
-function setPluginsView(appData, { plugins = {}, categories = {} }) {
+function setPluginsView(
+  appData,
+  { plugins = {}, categories = {}, core = null }
+) {
   appData.categories = categories;
   appData.plugins_flat = plugins;
+  appData.iitc_core = core;
   const category_name = appData.category_name;
   if (category_name !== "") {
     if (categories[category_name]) {
@@ -41,47 +32,6 @@ function setPluginsView(appData, { plugins = {}, categories = {} }) {
       appData.plugins = {};
     }
   }
-}
-
-function setIitcCore(appData, iitc_core, iitc_core_user) {
-  let core = iitc_core;
-  if (iitc_core_user && iitc_core_user.code) {
-    core = iitc_core_user;
-    core.override = true;
-    core.user = true;
-  }
-  appData.iitc_core = core;
-}
-
-export async function onChangedListener(self) {
-  const appData = self.$data;
-  browser.storage.onChanged.addListener(async function (changes) {
-    const data = await browser.storage.local.get("channel");
-    const channel = data.channel ? data.channel : "release";
-
-    for (let key in changes) {
-      const new_value = changes[key].newValue;
-
-      if (key === "channel") {
-        const storage = await browser.storage.local.get([
-          channel + "_iitc_core",
-          "iitc_core_user",
-        ]);
-        setIitcCore(
-          appData,
-          storage[channel + "_iitc_core"],
-          storage["iitc_core_user"]
-        );
-      }
-
-      if (key === "iitc_core_user") {
-        const storage = await browser.storage.local.get([
-          channel + "_iitc_core",
-        ]);
-        setIitcCore(appData, storage[channel + "_iitc_core"], new_value);
-      }
-    }
-  });
 }
 
 export async function onMessageListener(self) {

--- a/src/popup/data.js
+++ b/src/popup/data.js
@@ -10,9 +10,7 @@ export async function init(self) {
       "release_iitc_core",
       "beta_iitc_core",
       "custom_iitc_core",
-      "release_iitc_core_user",
-      "beta_iitc_core_user",
-      "custom_iitc_core_user",
+      "iitc_core_user",
     ]),
     browser.runtime.sendMessage({ type: "getPluginsView" }),
   ]);
@@ -20,11 +18,7 @@ export async function init(self) {
   // initialize plugins and categories from library
   setPluginsView(appData, view || {});
   // initialize iitc core
-  setIitcCore(
-    appData,
-    data[channel + "_iitc_core"],
-    data[channel + "_iitc_core_user"]
-  );
+  setIitcCore(appData, data[channel + "_iitc_core"], data["iitc_core_user"]);
 }
 
 function setPluginsView(appData, { plugins = {}, categories = {} }) {
@@ -71,16 +65,16 @@ export async function onChangedListener(self) {
       if (key === "channel") {
         const storage = await browser.storage.local.get([
           channel + "_iitc_core",
-          channel + "_iitc_core_user",
+          "iitc_core_user",
         ]);
         setIitcCore(
           appData,
           storage[channel + "_iitc_core"],
-          storage[channel + "_iitc_core_user"]
+          storage["iitc_core_user"]
         );
       }
 
-      if (key === channel + "_iitc_core_user") {
+      if (key === "iitc_core_user") {
         const storage = await browser.storage.local.get([
           channel + "_iitc_core",
         ]);

--- a/src/popup/data.js
+++ b/src/popup/data.js
@@ -4,26 +4,21 @@ import browser from "webextension-polyfill";
 
 export async function init(self) {
   const appData = self.$data;
-  const data = await browser.storage.local.get([
-    "channel",
-    "release_categories",
-    "beta_categories",
-    "custom_categories",
-    "release_plugins_flat",
-    "beta_plugins_flat",
-    "custom_plugins_flat",
-    "release_iitc_core",
-    "beta_iitc_core",
-    "custom_iitc_core",
-    "release_iitc_core_user",
-    "beta_iitc_core_user",
-    "custom_iitc_core_user",
+  const [data, view] = await Promise.all([
+    browser.storage.local.get([
+      "channel",
+      "release_iitc_core",
+      "beta_iitc_core",
+      "custom_iitc_core",
+      "release_iitc_core_user",
+      "beta_iitc_core_user",
+      "custom_iitc_core_user",
+    ]),
+    browser.runtime.sendMessage({ type: "getPluginsView" }),
   ]);
   const channel = data.channel ? data.channel : "release";
-  // initialize categories
-  appData.categories = data[channel + "_categories"];
-  // initialize all plugins
-  appData.plugins_flat = data[channel + "_plugins_flat"];
+  // initialize plugins and categories from library
+  setPluginsView(appData, view || {});
   // initialize iitc core
   setIitcCore(
     appData,
@@ -32,17 +27,13 @@ export async function init(self) {
   );
 }
 
-function setCategories(appData, categories) {
-  appData.categories = {};
+function setPluginsView(appData, { plugins = {}, categories = {} }) {
   appData.categories = categories;
-}
-
-function setPlugins(appData, plugins_flat) {
-  appData.plugins_flat = plugins_flat;
+  appData.plugins_flat = plugins;
   const category_name = appData.category_name;
   if (category_name !== "") {
-    if (appData.categories[category_name]) {
-      appData.plugins = Object.entries(plugins_flat).reduce(
+    if (categories[category_name]) {
+      appData.plugins = Object.entries(plugins).reduce(
         (category_plugins, plugin_pair) => {
           const [plugin_uid, plugin_obj] = plugin_pair;
           if (plugin_obj.category === category_name) {
@@ -79,26 +70,14 @@ export async function onChangedListener(self) {
 
       if (key === "channel") {
         const storage = await browser.storage.local.get([
-          channel + "_categories",
-          channel + "_plugins_flat",
           channel + "_iitc_core",
           channel + "_iitc_core_user",
         ]);
-        setCategories(appData, storage[channel + "_categories"]);
-        setPlugins(appData, storage[channel + "_plugins_flat"]);
         setIitcCore(
           appData,
           storage[channel + "_iitc_core"],
           storage[channel + "_iitc_core_user"]
         );
-      }
-
-      if (key === channel + "_categories") {
-        setCategories(appData, new_value);
-      }
-
-      if (key === channel + "_plugins_flat") {
-        setPlugins(appData, new_value);
       }
 
       if (key === channel + "_iitc_core_user") {
@@ -112,6 +91,7 @@ export async function onChangedListener(self) {
 }
 
 export async function onMessageListener(self) {
+  const appData = self.$data;
   browser.runtime.onMessage.addListener(function (request) {
     switch (request.type) {
       case "showProgressbar":
@@ -119,6 +99,9 @@ export async function onMessageListener(self) {
         break;
       case "showMessage":
         self.showMessage(request.message);
+        break;
+      case "pluginsViewChanged":
+        setPluginsView(appData, request);
         break;
     }
     return new Promise((resolve) => {


### PR DESCRIPTION
- Bump `lib-iitc-manager` to v2.0.1
- Adopt camelCase Manager config API
- Migrate plugins data to message-based `getPluginsView()`, get `iitc_core` from `PluginsView`
- Replace direct storage reads with manager API for `networkHost`, channel, and update intervals
- Replace local `validateCustomChannelUrl` with the library implementation
- Use exported UID constants instead of hardcoded strings
- Inline plugin matches, remove `getPluginMatches`
- Remove `<all_ingress>` handling from `getNiaTabsToInject`
- Fix: return early from `manage_userscripts_api` on unregister failure