### PR TITLE
Drop MV2 support and unpin Intel tab

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - build_script: build_mv2
           - build_script: build_mv3_firefox
           - build_script: build_mv3_chrome
           - build_script: build_mv3_safari

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "dev:firefox": "wxt -b firefox",
     "dev:chrome": "wxt -b chrome",
-    "build_mv2": "wxt build -b firefox --mv2 && wxt zip -b firefox --mv2",
     "build_mv3_firefox": "wxt build -b firefox --mv3 && wxt zip -b firefox --mv3",
     "build_mv3_chrome": "wxt build -b chrome --mv3 && wxt zip -b chrome --mv3",
     "build_mv3_safari": "wxt build -b safari --mv3 && wxt zip -b safari --mv3",

--- a/src/background/injector.js
+++ b/src/background/injector.js
@@ -4,36 +4,22 @@ import browser from "webextension-polyfill";
 import { GM_API_UID } from "lib-iitc-manager";
 import { getNiaTabsToInject } from "@/background/utils";
 import { is_userscripts_api_available } from "@/userscripts/utils";
-import { IS_LEGACY_API } from "@/userscripts/env";
-
 export async function inject_plugin_via_content_scripts(plugin) {
   const tabs = await getNiaTabsToInject(plugin);
   for (let tab of Object.values(tabs)) {
     try {
-      if (IS_LEGACY_API) {
-        const inject = `
-          document.dispatchEvent(new CustomEvent('IITCButtonInitJS', {
-            detail: ${JSON.stringify({ plugin })}
-          }));
-        `;
-        await browser.tabs.executeScript(tab.id, {
-          code: inject,
-          runAt: "document_end",
-        });
-      } else {
-        await browser.scripting.executeScript({
-          target: { tabId: tab.id },
-          func: (pluginDetail) => {
-            document.dispatchEvent(
-              new CustomEvent("IITCButtonInitJS", {
-                detail: pluginDetail,
-              }),
-            );
-          },
-          args: [{ plugin }],
-          injectImmediately: true,
-        });
-      }
+      await browser.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: (pluginDetail) => {
+          document.dispatchEvent(
+            new CustomEvent("IITCButtonInitJS", {
+              detail: pluginDetail,
+            }),
+          );
+        },
+        args: [{ plugin }],
+        injectImmediately: true,
+      });
     } catch (error) {
       console.error(
         `An error occurred while injecting script: ${error.message}`,

--- a/src/background/intel.js
+++ b/src/background/intel.js
@@ -18,7 +18,6 @@ export async function onRequestOpenIntel() {
   try {
     const tab = await browser.tabs.create({
       url: "https://intel.ingress.com/",
-      pinned: true,
     });
     lastIITCTab = tab.id;
   } catch (error) {

--- a/src/entrypoints/background.js
+++ b/src/entrypoints/background.js
@@ -1,11 +1,7 @@
 //@license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 import { Manager, GM_API_UID } from "lib-iitc-manager";
 import browser from "webextension-polyfill";
-import {
-  IS_LEGACY_API,
-  IS_SCRIPTING_API,
-  IS_USERSCRIPTS_API,
-} from "@/userscripts/env";
+import { IS_SCRIPTING_API, IS_USERSCRIPTS_API } from "@/userscripts/env";
 import { t } from "@/i18n";
 import {
   onUpdatedListener,
@@ -81,7 +77,7 @@ export default defineBackground(() => {
 
   manager.run().then();
 
-  if (IS_LEGACY_API || IS_SCRIPTING_API) {
+  if (IS_SCRIPTING_API) {
     const { onUpdated, onRemoved } = browser.tabs;
     onUpdated.addListener((tabId, status, tab) =>
       onUpdatedListener(tabId, status, tab, manager),
@@ -182,9 +178,7 @@ export default defineBackground(() => {
         break;
       case "setUpdateCheckInterval":
         await manager.setUpdateCheckInterval(request.interval, request.channel);
-        if (!IS_LEGACY_API) {
-          await createCheckUpdateAlarm(true);
-        }
+        await createCheckUpdateAlarm(true);
         break;
     }
   });
@@ -221,8 +215,6 @@ export default defineBackground(() => {
   }
 
   async function createCheckUpdateAlarm(need_to_update = false) {
-    if (IS_LEGACY_API) return;
-
     const alarm_name = "check-update-alarm";
     if (!need_to_update) {
       const alarm = await browser.alarms.get(alarm_name);
@@ -243,11 +235,9 @@ export default defineBackground(() => {
     });
   }
 
-  if (!IS_LEGACY_API) {
-    browser.alarms.onAlarm.addListener(async () => {
-      await manager.checkUpdates(false);
-    });
-  }
+  browser.alarms.onAlarm.addListener(async () => {
+    await manager.checkUpdates(false);
+  });
 
   browser.runtime.onInstalled.addListener((details) => {
     if (details.reason !== "update") return;

--- a/src/userscripts/env.js
+++ b/src/userscripts/env.js
@@ -6,8 +6,6 @@ export const IS_CHROME = !!browser.runtime.OnInstalledReason?.CHROME_UPDATE;
 export const IS_SAFARI =
   /^((?!chrome|android).)*safari/i.test(navigator.userAgent) ||
   (navigator.vendor && navigator.vendor.indexOf("Apple") > -1);
-export const MANIFEST = browser.runtime.getManifest();
 
-export const IS_USERSCRIPTS_API = IS_CHROME && MANIFEST.manifest_version === 3;
+export const IS_USERSCRIPTS_API = IS_CHROME;
 export const IS_SCRIPTING_API = !!browser.scripting;
-export const IS_LEGACY_API = !IS_USERSCRIPTS_API && !IS_SCRIPTING_API;

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -4,7 +4,7 @@ import { resolve, join } from "path";
 
 // Read manifest.json for base fields
 const baseManifest = JSON.parse(
-  readFileSync(resolve(__dirname, "src/manifest.json"), "utf-8")
+  readFileSync(resolve(__dirname, "src/manifest.json"), "utf-8"),
 );
 
 export default defineConfig({
@@ -47,106 +47,69 @@ export default defineConfig({
 
     const perms = result.permissions as string[];
 
-    if (manifestVersion === 2) {
-      // MV2 permissions
-      perms.push("<all_urls>", "webRequest", "webRequestBlocking");
-      // Gecko settings
+    perms.push("webRequest", "alarms");
+
+    result.host_permissions = [
+      "https://intel.ingress.com/*",
+      "http://*/*",
+      "https://*/*",
+    ];
+
+    result.action = {
+      default_title: "__MSG_titleDefault__",
+      default_icon: {
+        "48": isBeta
+          ? "assets/icons/48/icon-beta.png"
+          : "assets/icons/48/icon.png",
+        "96": isBeta
+          ? "assets/icons/96/icon-beta.png"
+          : "assets/icons/96/icon.png",
+      },
+    };
+
+    const isProd = mode === "production";
+
+    if (browser === "chrome") {
+      result.minimum_chrome_version = "120";
+      perms.push("userScripts", "declarativeNetRequest");
+      if (isProd) {
+        result.content_security_policy = {
+          extension_pages:
+            "default-src 'self'; connect-src 'self' http://localhost:8000 https://*; img-src 'self' https://* data:",
+        };
+      }
+      // web_accessible_resources for jsview and sandbox
+      result.web_accessible_resources = [
+        {
+          resources: ["sandbox.html", "jsview.html"],
+          matches: ["<all_urls>"],
+        },
+      ];
+    } else if (browser === "firefox" || browser === "safari") {
       result.browser_specific_settings = {
         gecko: {
           id: isBeta ? "iitc-beta@modos189.ru" : "iitc@modos189.ru",
-          strict_min_version: "57.0",
+          strict_min_version: "109.0",
         },
         gecko_android: {
           strict_min_version: "113.0",
         },
       };
-      // browser_action icon/title (WXT adds default_popup automatically)
-      result.browser_action = {
-        default_title: "__MSG_titleDefault__",
-        default_icon: {
-          "48": isBeta
-            ? "assets/icons/48/icon-beta.png"
-            : "assets/icons/48/icon.png",
-          "96": isBeta
-            ? "assets/icons/96/icon-beta.png"
-            : "assets/icons/96/icon.png",
-        },
-      };
+      perms.push("webRequestBlocking", "scripting");
 
-      // web_accessible_resources for sandbox in MV2
-      result.web_accessible_resources = ["sandbox.html"];
-
-      if (browser === "safari-ios") {
-        // persistent:false for safari-ios - WXT will handle background but we note it
-        result.background = { persistent: false };
-      }
-    } else {
-      // MV3 permissions
-      perms.push("webRequest", "alarms");
-
-      result.host_permissions = [
-        "https://intel.ingress.com/*",
-        "http://*/*",
-        "https://*/*",
-      ];
-
-      // Default action (WXT derives popup from entrypoint; we set title and icon)
-      result.action = {
-        default_title: "__MSG_titleDefault__",
-        default_icon: {
-          "48": isBeta
-            ? "assets/icons/48/icon-beta.png"
-            : "assets/icons/48/icon.png",
-          "96": isBeta
-            ? "assets/icons/96/icon-beta.png"
-            : "assets/icons/96/icon.png",
-        },
-      };
-
-      const isProd = mode === "production";
-
-      if (browser === "chrome") {
-        result.minimum_chrome_version = "120";
-        perms.push("userScripts", "declarativeNetRequest");
-        if (isProd) {
-          result.content_security_policy = {
-            extension_pages:
-              "default-src 'self'; connect-src 'self' http://localhost:8000 https://*; img-src 'self' https://* data:",
-          };
-        }
-        // web_accessible_resources for jsview and sandbox
-        result.web_accessible_resources = [
-          {
-            resources: ["sandbox.html", "jsview.html"],
-            matches: ["<all_urls>"],
-          },
-        ];
-      } else if (browser === "firefox" || browser === "safari") {
-        result.browser_specific_settings = {
-          gecko: {
-            id: isBeta ? "iitc-beta@modos189.ru" : "iitc@modos189.ru",
-            strict_min_version: "109.0",
-          },
-          gecko_android: {
-            strict_min_version: "113.0",
-          },
+      if (browser === "firefox" && isProd) {
+        result.content_security_policy = {
+          extension_pages:
+            "default-src 'self'; connect-src 'self' http://localhost:8000 https://*; img-src 'self' https://* data:",
         };
-        perms.push("webRequestBlocking", "scripting");
-
-        if (browser === "firefox" && isProd) {
-          result.content_security_policy = {
-            extension_pages:
-              "default-src 'self'; connect-src 'self' http://localhost:8000 https://*; img-src 'self' https://* data:",
-          };
-        }
-        // Safari: no CSP
-        result.web_accessible_resources = [
-          {
-            resources: ["sandbox.html"],
-            matches: ["<all_urls>"],
-          },
-        ];
       }
+      // Safari: no CSP
+      result.web_accessible_resources = [
+        {
+          resources: ["sandbox.html"],
+          matches: ["<all_urls>"],
+        },
+      ];
     }
 
     return result;
@@ -158,7 +121,8 @@ export default defineConfig({
     // The Firefox AMO sources zip is generated on demand by `npm run zip_sources` (wxt zip --sources).
     zipSources: false,
     // Built into .output first, then copied to artifacts/ via the zip hooks below.
-    artifactTemplate: "{{name}}-v{{version}}-{{browser}}-{{manifestVersion}}.zip",
+    artifactTemplate:
+      "{{name}}-v{{version}}-{{browser}}-{{manifestVersion}}.zip",
     sourcesTemplate: "iitc-button-v{{version}}-sources.zip",
     exclude: ["**/.DS_Store"],
     excludeSources: ["**/artifacts/**", "**/safari/**", "**/*.zip"],
@@ -172,12 +136,10 @@ export default defineConfig({
       const artifactsDir = resolve(wxt.config.root, "artifacts");
       mkdirSync(artifactsDir, { recursive: true });
 
-      // Determine the browser label: MV2 uses "all", MV3 uses actual browser
-      const browserLabel =
-        wxt.config.manifestVersion === 2 ? "all" : wxt.config.browser;
+      const browserLabel = wxt.config.browser;
       const mv = `MV${wxt.config.manifestVersion}`;
       const version = JSON.parse(
-        readFileSync(resolve(wxt.config.root, "package.json"), "utf-8")
+        readFileSync(resolve(wxt.config.root, "package.json"), "utf-8"),
       ).version;
       const name = "iitc-button";
 


### PR DESCRIPTION
Remove all Manifest V2 code paths, keeping only MV3.
Also open the Intel tab as a regular tab instead of a pinned one. fix https://github.com/IITC-CE/IITC-Button/issues/24