### PR TITLE
Fix popup showing default channel on cold background start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@highlightjs/vue-plugin": "^2.1.0",
         "highlight.js": "^11.11.1",
         "jszip": "^3.10.1",
-        "lib-iitc-manager": "^2.0.1",
+        "lib-iitc-manager": "^2.1.0",
         "mitt": "^3.0.1",
         "scored-fuzzysearch": "^1.0.5",
         "vue": "^3.5.35"
@@ -232,10 +232,10 @@
       }
     },
     "node_modules/@bundled-es-modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==",
-      "license": "ISC",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/deepmerge/-/deepmerge-4.3.2.tgz",
+      "integrity": "sha512-q8doe7ndrY2IolUOFIn0A0++JBX38pMhN7kFhTF4cnjIcILf6X6H2yWczInyv8ZFdR0lrE8088X8XS5efxXz8A==",
+      "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.3.1"
       }
@@ -4753,9 +4753,9 @@
       }
     },
     "node_modules/lib-iitc-manager": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-2.0.1.tgz",
-      "integrity": "sha512-iynZ2xgegyy4SWD50dvIRTAFmGeB871MZW91ZpxiRqUrgFweWkbnJbP8saSUfVQsiaJ6HkxMoQCnsBXqNuwr8A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-2.1.0.tgz",
+      "integrity": "sha512-mFav0Z5wvlxGKi6oPS8CIUjxawFSKNEBloLE27U/pUsO1zUrlnqZZvoXL/dFFq47YkWZr/sNOPsZ1I7j72JYfg==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@highlightjs/vue-plugin": "^2.1.0",
     "highlight.js": "^11.11.1",
     "jszip": "^3.10.1",
-    "lib-iitc-manager": "^2.0.1",
+    "lib-iitc-manager": "^2.1.0",
     "mitt": "^3.0.1",
     "scored-fuzzysearch": "^1.0.5",
     "vue": "^3.5.35"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "license": "GPLv3",
   "private": true,
   "scripts": {
-    "dev:firefox": "wxt -b firefox",
-    "dev:chrome": "wxt -b chrome",
+    "dev:firefox": "wxt -b firefox --mv3",
+    "dev:chrome": "wxt -b chrome --mv3",
+    "dev:firefox:link": "LINK_LIB=1 wxt -b firefox --mv3",
+    "dev:chrome:link": "LINK_LIB=1 wxt -b chrome --mv3",
     "build_mv3_firefox": "wxt build -b firefox --mv3 && wxt zip -b firefox --mv3",
     "build_mv3_chrome": "wxt build -b chrome --mv3 && wxt zip -b chrome --mv3",
     "build_mv3_safari": "wxt build -b safari --mv3 && wxt zip -b safari --mv3",

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -91,6 +91,9 @@ export default defineBackground(() => {
   browser.runtime.onMessage.addListener(
     async (request: unknown, sender: WebExt.Runtime.MessageSender) => {
       const msg = request as BackgroundMessage;
+      // A cold-started background can receive a message before the Manager has
+      // loaded channel/networkHost from storage - wait so handlers never read defaults.
+      await manager.ready;
       switch (msg.type) {
         case "requestOpenIntel":
           await onRequestOpenIntel();

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -169,6 +169,11 @@ export default defineConfig({
     },
     resolve: {
       extensions: [".mjs", ".js", ".ts", ".jsx", ".tsx", ".json", ".vue"],
+      // Local-only: a linked (file:) dependency resolves to its real path outside
+      // node_modules, which leaks WXT auto-imports into it and breaks the build.
+      // Keeping symlinks unresolved keeps it under node_modules so WXT skips it.
+      // Enable via the dev:*:link scripts (LINK_LIB=1); off for normal/CI builds.
+      preserveSymlinks: !!process.env.LINK_LIB,
     },
   }),
 });


### PR DESCRIPTION
- **Fix:** on a cold event-page/service-worker start, the popup could request the channel / custom-server URL before the Manager had loaded them from storage. Handlers returned `undefined` and the popup fell back to defaults (e.g. showing `release` while a custom channel was active). Now handlers await the new `manager.ready` promise (lib-iitc-manager 2.1.0) before dispatching.
- **Build/dev:** `dev:firefox`/`dev:chrome` now pass `--mv3` (MV2 is gone from the build matrix). Added `dev:*:link` (`LINK_LIB=1`) for testing a `file:`-linked lib-iitc-manager — it gates Vite's `preserveSymlinks` so WXT auto-imports don't leak into the linked dep. Off for normal/CI builds.