### PR TITLE
fix: restore built-in plugins lost after upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@highlightjs/vue-plugin": "^2.1.0",
         "highlight.js": "^11.11.1",
         "jszip": "^3.10.1",
-        "lib-iitc-manager": "^2.1.2",
+        "lib-iitc-manager": "^2.1.3",
         "mitt": "^3.0.1",
         "overlayscrollbars": "^2.16.0",
         "overlayscrollbars-vue": "^0.5.10",
@@ -4755,9 +4755,9 @@
       }
     },
     "node_modules/lib-iitc-manager": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-2.1.2.tgz",
-      "integrity": "sha512-pi6WCI2V8x0xxhtY9aSzjdMMjqjuHKa7qV0eMQdbFgfWbjQwg98xSs2Gv770KnuRYuHyuVrl21RCf/e5BEP5TQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lib-iitc-manager/-/lib-iitc-manager-2.1.3.tgz",
+      "integrity": "sha512-srXI/mDkZEumhxGRrVu0kll56JnrHwmrSh5vHkvx+eFXDNU+t5boWVA8Q3/a6TbKv8vbdg4hN7vwgmSv1UzxKA==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@highlightjs/vue-plugin": "^2.1.0",
     "highlight.js": "^11.11.1",
     "jszip": "^3.10.1",
-    "lib-iitc-manager": "^2.1.2",
+    "lib-iitc-manager": "^2.1.3",
     "mitt": "^3.0.1",
     "overlayscrollbars": "^2.16.0",
     "overlayscrollbars-vue": "^0.5.10",

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -78,7 +78,9 @@ export default defineBackground(() => {
     isDaemon: true,
   });
 
-  manager.run().then();
+  manager.run().catch((error) => {
+    console.error("IITC Button: manager startup failed", error);
+  });
 
   if (IS_SCRIPTING_API) {
     const { onUpdated, onRemoved } = browser.tabs;


### PR DESCRIPTION
Some users lost their enabled built-in plugins after upgrading to 4.0.0. Root cause and fix are in the library:
IITC-CE/lib-iitc-manager#82 - this PR bumps lib-iitc-manager to that release, which also auto-recovers affected users on next launch.

Also stop swallowing a failed `manager.run()` in the background: log it so a broken startup surfaces in the console instead of silently leaving an empty plugin list.