### PR TITLE
fix(background): inject built-in plugins on Firefox when local match is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iitc-button",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iitc-button",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "hasInstallScript": true,
       "license": "GPLv3",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iitc-button",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "repository": "https://github.com/IITC-CE/IITC-Button.git",
   "license": "GPLv3",
   "private": true,

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -15,7 +15,12 @@ export async function getTabsToInject() {
 // Filter all completly loaded Ingress Intel tabs
 export async function getNiaTabsToInject(plugin: Plugin) {
   const tabs = await getTabsToInject();
+  // Fallback to the intel origin when match/include is empty
+  const target =
+    plugin.match || plugin.include
+      ? plugin
+      : { ...plugin, match: ["https://intel.ingress.com/*"] };
   return Object.values(tabs).filter(
-    (tab) => tab.url && checkMatching(plugin, tab.url),
+    (tab) => tab.url && checkMatching(target, tab.url),
   );
 }


### PR DESCRIPTION
Firefox injects plugins via the scripting API, filtering tabs with `checkMatching`.
Cached built-in `plugins_local` entries lack `match`/`include`, so every tab is rejected and the plugin never injects (user plugins have a match, so they work;
Chrome defaults the match already).
Fall back to the intel origin when match is empty.