### PR TITLE
chore(ci): fix beta version and modernize build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies
@@ -39,13 +39,13 @@ jobs:
           - build_script: build_mv3_chrome
           - build_script: build_mv3_safari
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies
@@ -59,13 +59,6 @@ jobs:
 
       - name: Build
         run: npm run ${{ matrix.build_script }}
-
-      - name: Get version from package.json
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: polyseam/get-version-key-from-json@v1.0.0
-        id: get-version-key-from-json
-        with:
-          path-to-json: './package.json'
 
       - name: Save metadata
         run: |
@@ -107,7 +100,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.FILE_NAME }}
           include-hidden-files: true
@@ -119,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: collected_artifacts
 
@@ -139,7 +132,7 @@ jobs:
         run: echo "GITHUB_SHA_SHORT=$(cat ./final_artifacts/.metadata/commit | cut -c 1-6)" >> $GITHUB_ENV
 
       - name: Upload general artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: iitc-button-${{ env.GITHUB_SHA_SHORT }}-artifacts
           include-hidden-files: true

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Get artifact list from API
         id: get-artifacts
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -34,7 +34,7 @@ jobs:
             core.exportVariable("firstArtifactId", artifacts.data.artifacts[0].id);
 
       - name: Download first artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Comment with artifact links for PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         if: ${{ env.PR_NUMBER != '' }}
         with:
           header: pr_artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,11 +29,11 @@ jobs:
     if: needs.check-secret.outputs.secrets == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Get artifact ID and name from API
         id: get-artifact-id
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -61,7 +61,7 @@ jobs:
             }
 
       - name: Download Chrome artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -75,7 +75,7 @@ jobs:
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/build-chrome.zip`, Buffer.from(download.data));
 
       - name: Download Firefox artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -110,10 +110,10 @@ jobs:
           echo "CHROME_ZIP=./build-chrome/${{ env.chromeArtifactName }}.zip" >> $GITHUB_ENV
           echo "FIREFOX_ZIP=./build-firefox/${{ env.firefoxArtifactName }}.zip" >> $GITHUB_ENV
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: ${{ contains(fromJSON('["release", "beta"]'), env.BUILD_TYPE) }}
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,8 +15,8 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -39,4 +39,4 @@ jobs:
           node-version: lts/*
           cache: npm
       - run: npm ci
-      - run: npx vue-tsc --noEmit
+      - run: npm run typecheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "publish-browser-extension": "^2.1.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.1",
+        "vue-tsc": "^3.3.7",
         "webextension-polyfill": "^0.10.0",
         "wxt": "^0.20.26"
       }
@@ -1902,6 +1903,35 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.35",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz",
@@ -1950,6 +1980,22 @@
       "dependencies": {
         "@vue/compiler-dom": "3.5.35",
         "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.7.tgz",
+      "integrity": "sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.1",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -2123,6 +2169,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -5659,6 +5712,13 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/multimatch": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-6.0.0.tgz",
@@ -6040,6 +6100,13 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7629,6 +7696,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue": {
       "version": "3.5.35",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz",
@@ -7721,6 +7795,23 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.7.tgz",
+      "integrity": "sha512-+C+rgD49wAQ5bUTl2sp5a8Bzg4YoldMNXM+g7CFe604MYcQ8PrZPMQhIjJSzKXtPBCa+C5ayMipqjbA7splekQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.7"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "publish-browser-extension": "^2.1.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
+    "vue-tsc": "^3.3.7",
     "webextension-polyfill": "^0.10.0",
     "wxt": "^0.20.26"
   },

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -2,9 +2,8 @@ import { defineConfig } from "wxt";
 import { readFileSync } from "fs";
 import { resolve, join } from "path";
 
-// Read manifest.json for base fields
-const baseManifest = JSON.parse(
-  readFileSync(resolve(__dirname, "src/manifest.json"), "utf-8"),
+const pkg = JSON.parse(
+  readFileSync(resolve(__dirname, "package.json"), "utf-8"),
 );
 
 export default defineConfig({
@@ -20,7 +19,7 @@ export default defineConfig({
 
   manifest: ({ browser, mode }) => {
     const isBeta = !!process.env.BETA;
-    const version = baseManifest.version ?? "3.2.5";
+    const version = pkg.version;
 
     // Build base manifest fields we control (WXT handles action/background/content_scripts)
     const result: Record<string, unknown> = {


### PR DESCRIPTION
- Derive build version from `package.json` so beta builds stop falling back to a hardcoded `3.2.5` (release -> `4.0.2`, beta -> `4.0.2.{revCount}`).
- Bump all actions to latest majors on Node 24 (checkout v7, setup-node v6, upload-artifact v7, download-artifact v8, github-script v9, sticky-pull-request-comment v3) and Node 20 -> 22, clearing the Node 20 warnings.
- Drop the unused `get-version-key-from-json` step that emitted the deprecated `set-output` command on releases.
- Pin `vue-tsc` (undeclared before, so CI pulled a floating version incompatible with TypeScript 6) and run `npm run typecheck` against the local binary.